### PR TITLE
feature/recommendations/recommendation page UI with mock up data

### DIFF
--- a/frontend/src/pages/TeamBrowser.jsx
+++ b/frontend/src/pages/TeamBrowser.jsx
@@ -15,8 +15,11 @@ import LinearProgress from '@mui/material/LinearProgress';
 import CircularProgress from '@mui/material/CircularProgress';
 import Alert from '@mui/material/Alert';
 import Stack from '@mui/material/Stack';
+import Tooltip from '@mui/material/Tooltip';
 import SearchIcon from '@mui/icons-material/Search';
 import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord';
+import PersonOutlinedIcon from '@mui/icons-material/PersonOutlined';
+import GroupsOutlinedIcon from '@mui/icons-material/GroupsOutlined';
 import NavigationSidebar from '../components/NavigationSidebar';
 import { getClient } from '../lib/supabase';
 
@@ -169,13 +172,216 @@ function TeamCard({ team, isMyTeam, matchPct, onView, onRequestMerge }) {
   );
 }
 
+const MOCK_RECOMMENDATIONS = [
+  {
+    id: 'rec-1',
+    type: 'person',
+    name: 'Jordan Kim',
+    members: [
+      { id: 'u-jk', name: 'Jordan Kim', school: 'Amherst College', major: 'Computer Science', gradYear: 2027 },
+    ],
+    maxSize: 4,
+    description: 'Looking for a team for the hackathon. Strong in full-stack dev and ML. Night-owl coder, prefer async communication.',
+    matchPct: 94,
+    spotsLeft: 3,
+  },
+  {
+    id: 'rec-2',
+    type: 'team',
+    name: 'The Debug Ducks',
+    members: [
+      { id: 'u-ms', name: 'Maya Singh', school: 'Hampshire College', major: 'Data Science', gradYear: 2026 },
+      { id: 'u-lo', name: 'Leo Ortega', school: 'Mount Holyoke', major: 'Statistics', gradYear: 2027 },
+    ],
+    maxSize: 4,
+    description: 'Working on a data visualization project for public health. Need 2 more members with frontend or design skills.',
+    matchPct: 87,
+    spotsLeft: 2,
+  },
+  {
+    id: 'rec-3',
+    type: 'person',
+    name: 'Sam Rivera',
+    members: [
+      { id: 'u-sr', name: 'Sam Rivera', school: 'Smith College', major: 'UI/UX Design', gradYear: 2026 },
+    ],
+    maxSize: 4,
+    description: 'Designer looking for an engineering team. Experienced with Figma and user research. Passionate about accessibility.',
+    matchPct: 79,
+    spotsLeft: 3,
+  },
+  {
+    id: 'rec-4',
+    type: 'team',
+    name: 'Circuit Breakers',
+    members: [
+      { id: 'u-ec', name: 'Ethan Cole', school: 'Amherst College', major: 'Physics', gradYear: 2025 },
+      { id: 'u-pw', name: 'Priya Wen', school: 'UMass Amherst', major: 'Electrical Engineering', gradYear: 2026 },
+      { id: 'u-nb', name: 'Noah Brooks', school: 'UMass Amherst', major: 'Computer Engineering', gradYear: 2027 },
+    ],
+    maxSize: 5,
+    description: 'Hardware + software team building an IoT sensor platform. Strong embedded systems background.',
+    matchPct: 68,
+    spotsLeft: 2,
+  },
+  {
+    id: 'rec-5',
+    type: 'person',
+    name: 'Ava Thompson',
+    members: [
+      { id: 'u-at', name: 'Ava Thompson', school: 'Hampshire College', major: 'Cognitive Science', gradYear: 2027 },
+    ],
+    maxSize: 4,
+    description: 'Interested in NLP and conversational AI. Also enjoys product management and bridging the gap between users and devs.',
+    matchPct: 61,
+    spotsLeft: 3,
+  },
+  {
+    id: 'rec-6',
+    type: 'team',
+    name: 'Green Stack',
+    members: [
+      { id: 'u-fw', name: 'Fatima Wali', school: 'Mount Holyoke', major: 'Environmental Science', gradYear: 2026 },
+      { id: 'u-cl', name: 'Chris Lau', school: 'Amherst College', major: 'Computer Science', gradYear: 2026 },
+    ],
+    maxSize: 4,
+    description: 'Building a sustainability tracking app. Combining env science domain knowledge with tech.',
+    matchPct: 53,
+    spotsLeft: 2,
+  },
+];
+
+// Returns a MUI color string based on a percentage value
+function matchColor(pct) {
+  if (pct >= 85) return 'success';
+  if (pct >= 65) return 'primary';
+  if (pct >= 45) return 'warning';
+  return 'error';
+}
+
+// ── Recommended card ──────────────────────────────────────────────────────────
+
+function RecommendedCard({ rec, rank }) {
+  const color = matchColor(rec.matchPct);
+  const isSolo = rec.type === 'person';
+
+  return (
+    <Paper
+      variant="outlined"
+      sx={{
+        p: 0, display: 'flex', flexDirection: 'column',
+        bgcolor: 'background.paper',
+        transition: 'box-shadow 0.15s, transform 0.15s',
+        overflow: 'hidden',
+        '&:hover': { boxShadow: 4, transform: 'translateY(-2px)' },
+      }}
+    >
+      {/* Top accent bar coloured by match strength */}
+      <Box sx={{ height: 3, bgcolor: `${color}.main` }} />
+
+      <Box sx={{ p: 2.25, display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+
+        {/* ── Header row ───────────────────────────────────────────────── */}
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 1 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Box
+              sx={{
+                width: 28, height: 28, borderRadius: '50%', flexShrink: 0,
+                bgcolor: isSolo ? 'primary.50' : 'grey.100',
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+              }}
+            >
+              {isSolo
+                ? <PersonOutlinedIcon sx={{ fontSize: 16, color: 'primary.main' }} />
+                : <GroupsOutlinedIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+              }
+            </Box>
+            <Box>
+              <Typography variant="body2" fontWeight={600} sx={{ lineHeight: 1.3 }}>{rec.name}</Typography>
+              <Typography variant="caption" color="text.disabled" fontFamily="monospace">
+                {isSolo ? 'Looking for a team' : `${rec.members.length} member${rec.members.length !== 1 ? 's' : ''} · ${rec.spotsLeft} spot${rec.spotsLeft !== 1 ? 's' : ''} left`}
+              </Typography>
+            </Box>
+          </Box>
+
+          {/* Match badge */}
+          <Box sx={{ textAlign: 'right', flexShrink: 0 }}>
+            <Typography variant="body2" fontWeight={700} color={`${color}.main`} fontFamily="monospace" sx={{ lineHeight: 1.2 }}>
+              {rec.matchPct}%
+            </Typography>
+            <Typography variant="caption" color="text.disabled" fontFamily="monospace">match</Typography>
+          </Box>
+        </Box>
+
+        {/* ── Overall match bar ─────────────────────────────────────────── */}
+        <LinearProgress
+          variant="determinate"
+          value={rec.matchPct}
+          color={color}
+          sx={{ height: 5, borderRadius: 3 }}
+        />
+
+        {/* ── Member avatars ────────────────────────────────────────────── */}
+        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+          {rec.members.map((m, i) => (
+            <Tooltip key={m.id} title={`${m.name} · ${m.school}`} arrow placement="top">
+              <Avatar
+                sx={{
+                  width: 26, height: 26, fontSize: 10, fontWeight: 600,
+                  bgcolor: avatarColor(m.id),
+                  border: '2px solid white',
+                  ml: i === 0 ? 0 : '-6px',
+                  cursor: 'default',
+                }}
+              >
+                {initials(m.name)}
+              </Avatar>
+            </Tooltip>
+          ))}
+          {Array.from({ length: Math.max(0, rec.spotsLeft) }).map((_, i) => (
+            <Box
+              key={`slot-${i}`}
+              sx={{
+                width: 26, height: 26, borderRadius: '50%',
+                border: '1.5px dashed', borderColor: 'divider',
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                color: 'text.disabled', fontSize: 13,
+                ml: rec.members.length === 0 && i === 0 ? 0 : '-6px',
+              }}
+            >
+              +
+            </Box>
+          ))}
+          <Typography variant="caption" fontFamily="monospace" color="text.disabled" sx={{ ml: 1 }}>
+            {rec.members.length} / {rec.maxSize}
+          </Typography>
+        </Box>
+
+        {/* ── Description ───────────────────────────────────────────────── */}
+        {rec.description && (
+          <Typography variant="caption" color="text.secondary" sx={{ lineHeight: 1.55 }}>
+            {rec.description}
+          </Typography>
+        )}
+
+        {/* ── Action ────────────────────────────────────────────────────── */}
+        <Button
+          variant="contained"
+          size="small"
+          fullWidth
+          sx={{ fontSize: 12, py: 0.75, mt: 0.25 }}
+        >
+          {isSolo ? 'Invite to team' : 'Request merge'}
+        </Button>
+      </Box>
+    </Paper>
+  );
+}
+
 // ── Main component ────────────────────────────────────────────────────────────
 
 // For demo: treat the first team as "my team" (no real auth in demo mode)
 const DEMO_MY_TEAM_INDEX = 0;
-
-// Mock match scores for Recommended tab (real algorithm is Contributor N's work)
-const MOCK_MATCH_SCORES = [91, 74, 58, 45];
 
 export default function TeamBrowser() {
   const navigate = useNavigate();
@@ -186,6 +392,7 @@ export default function TeamBrowser() {
   const [tab, setTab]           = useState('all');
   const [search, setSearch]     = useState('');
   const [openOnly, setOpenOnly] = useState(false);
+  const [recFilter, setRecFilter] = useState('all'); // 'all' | 'person' | 'team'
 
   useEffect(() => {
     fetchBrowserData()
@@ -205,13 +412,10 @@ export default function TeamBrowser() {
     });
   }, [data, search, openOnly]);
 
-  const recommended = useMemo(() => {
-    if (!data) return [];
-    return data.teams
-      .filter((_, i) => i !== DEMO_MY_TEAM_INDEX)
-      .map((t, i) => ({ ...t, matchPct: MOCK_MATCH_SCORES[i] ?? 40 }))
-      .sort((a, b) => b.matchPct - a.matchPct);
-  }, [data]);
+  // Recommended tab uses the static mock data (real algorithm to be wired in later)
+  const recommended = recFilter === 'all'
+    ? MOCK_RECOMMENDATIONS
+    : MOCK_RECOMMENDATIONS.filter(r => r.type === recFilter);
 
   function handleView(teamId) {
     navigate(`/teams/${teamId}`);
@@ -387,29 +591,83 @@ export default function TeamBrowser() {
         {/* ── Recommended ───────────────────────────────────────────────────── */}
         {tab === 'recommended' && (
           <>
-            <Typography variant="body2" color="text.secondary" mb={2.5}>
-              Ranked by how well their survey responses match yours.
-            </Typography>
+            {/* Sub-header */}
+            <Box sx={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 2, mb: 2.5, flexWrap: 'wrap' }}>
+              <Box>
+                <Typography variant="body2" color="text.secondary">
+                  Ranked by how well their survey responses match yours. Includes both solo people and partial teams you can join or merge with.
+                </Typography>
+              </Box>
+              <Box sx={{ display: 'flex', gap: 1, flexShrink: 0 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                  <Box sx={{ width: 8, height: 8, borderRadius: '50%', bgcolor: 'success.main' }} />
+                  <Typography variant="caption" color="text.secondary" fontFamily="monospace">85–100%</Typography>
+                </Box>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                  <Box sx={{ width: 8, height: 8, borderRadius: '50%', bgcolor: 'primary.main' }} />
+                  <Typography variant="caption" color="text.secondary" fontFamily="monospace">65–84%</Typography>
+                </Box>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                  <Box sx={{ width: 8, height: 8, borderRadius: '50%', bgcolor: 'warning.main' }} />
+                  <Typography variant="caption" color="text.secondary" fontFamily="monospace">45–64%</Typography>
+                </Box>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                  <Box sx={{ width: 8, height: 8, borderRadius: '50%', bgcolor: 'error.main' }} />
+                  <Typography variant="caption" color="text.secondary" fontFamily="monospace">&lt;45%</Typography>
+                </Box>
+              </Box>
+            </Box>
+
+            {/* Type filter */}
+            <Box sx={{ display: 'flex', gap: 1, mb: 2.5, alignItems: 'center', flexWrap: 'wrap' }}>
+              <Typography variant="caption" color="text.disabled" fontFamily="monospace" sx={{ mr: 0.5 }}>
+                Show:
+              </Typography>
+              {[
+                { id: 'all',    label: 'All',         icon: null },
+                { id: 'person', label: 'Solo people',  icon: <PersonOutlinedIcon sx={{ fontSize: 14 }} /> },
+                { id: 'team',   label: 'Teams',        icon: <GroupsOutlinedIcon sx={{ fontSize: 14 }} /> },
+              ].map(opt => {
+                const active = recFilter === opt.id;
+                return (
+                  <Box
+                    key={opt.id}
+                    component="button"
+                    onClick={() => setRecFilter(opt.id)}
+                    sx={{
+                      display: 'flex', alignItems: 'center', gap: 0.6,
+                      px: 1.5, py: 0.6,
+                      borderRadius: 1,
+                      border: '1px solid',
+                      borderColor: active ? 'primary.main' : 'divider',
+                      bgcolor: active ? 'primary.50' : 'background.paper',
+                      color: active ? 'primary.main' : 'text.secondary',
+                      cursor: 'pointer',
+                      fontFamily: 'DM Sans, sans-serif',
+                      fontSize: 12,
+                      fontWeight: active ? 600 : 400,
+                      transition: 'all 0.15s',
+                    }}
+                  >
+                    {opt.icon}
+                    {opt.label}
+                  </Box>
+                );
+              })}
+              <Typography variant="caption" fontFamily="monospace" color="text.disabled" sx={{ ml: 'auto' }}>
+                {recommended.length} result{recommended.length !== 1 ? 's' : ''}
+              </Typography>
+            </Box>
+
             {recommended.length === 0 ? (
               <Typography variant="body2" color="text.disabled" textAlign="center" mt={6}>
-                No other teams found.
+                No recommendations available yet.
               </Typography>
             ) : (
-              <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(210px, 1fr))', gap: 1.75 }}>
-                {recommended.map((team, i) => (
-                  <Box key={team.id} sx={{ position: 'relative' }}>
-                    {i === 0 && (
-                      <Box sx={{ position: 'absolute', top: -10, right: 12, zIndex: 1, bgcolor: 'primary.main', color: 'white', fontSize: 10, fontFamily: 'monospace', px: 1, py: '2px', borderRadius: '100px' }}>
-                        Top match
-                      </Box>
-                    )}
-                    <TeamCard
-                      team={team}
-                      isMyTeam={false}
-                      matchPct={team.matchPct}
-                      onView={handleView}
-                      onRequestMerge={handleRequestMerge}
-                    />
+              <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(260px, 1fr))', gap: 1.75 }}>
+                {recommended.map((rec, i) => (
+                  <Box key={rec.id}>
+                    <RecommendedCard rec={rec} rank={i + 1} />
                   </Box>
                 ))}
               </Box>


### PR DESCRIPTION
Implements a demo version of the Recommendations tab within the TeamBrowser pages using mock data. The mock data can be replaced with an API response once the endpoint is available.

Changes
- Display recommendations in the Recommendations tab + compatibility score
- Filter recommendations based on solo/non-solo teammates (single vs. multiple people)
- Mock data layer in place for future API integration