### PR TITLE
Feature/merge request

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from routers.auth import router as auth_router
 from routers.recommendations import router as recommendations_router
+from routers.teams import router as teams_router
 
 app = FastAPI(
     title="Common Ground API",
@@ -22,6 +23,7 @@ app.add_middleware(
 
 app.include_router(auth_router)
 app.include_router(recommendations_router)
+app.include_router(teams_router)
 
 
 @app.get("/health", tags=["meta"])

--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -78,3 +78,17 @@ class TeamCreate(BaseModel):
 
 class TeamMemberUpdate(BaseModel):
     status: str  # "approved" | "rejected"
+
+
+# ── Merge Requests ────────────────────────────────────────────────────────────
+
+class MergeRequestCreate(BaseModel):
+    requesting_team_id: str
+
+
+class MergeRequestResponse(BaseModel):
+    id: str
+    requesting_team_id: str
+    target_team_id: str
+    status: str
+    created_at: datetime

--- a/backend/routers/teams.py
+++ b/backend/routers/teams.py
@@ -26,12 +26,12 @@ async def create_merge_request(
         supabase_admin.table("teams")
         .select("id, created_by")
         .eq("id", requesting_team_id)
-        .maybe_single()
+        .limit(1)
         .execute()
     )
     if not req_team.data:
         raise HTTPException(status_code=404, detail="Requesting team not found.")
-    if req_team.data["created_by"] != user_id:
+    if req_team.data[0]["created_by"] != user_id:
         raise HTTPException(status_code=403, detail="You are not the creator of the requesting team.")
 
     # Target team must exist
@@ -39,7 +39,7 @@ async def create_merge_request(
         supabase_admin.table("teams")
         .select("id")
         .eq("id", team_id)
-        .maybe_single()
+        .limit(1)
         .execute()
     )
     if not target_team.data:
@@ -52,7 +52,7 @@ async def create_merge_request(
         .eq("requesting_team_id", requesting_team_id)
         .eq("target_team_id", team_id)
         .eq("status", "pending")
-        .maybe_single()
+        .limit(1)
         .execute()
     )
     if existing.data:

--- a/backend/routers/teams.py
+++ b/backend/routers/teams.py
@@ -1,3 +1,74 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException, status
+from auth import get_user_id
+from db import supabase_admin
+from models.schemas import MergeRequestCreate, MergeRequestResponse
 
 router = APIRouter(prefix="/teams", tags=["teams"])
+
+
+@router.post(
+    "/{team_id}/merge-requests",
+    response_model=MergeRequestResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_merge_request(
+    team_id: str,
+    body: MergeRequestCreate,
+    user_id: str = Depends(get_user_id),
+):
+    requesting_team_id = body.requesting_team_id
+
+    if requesting_team_id == team_id:
+        raise HTTPException(status_code=400, detail="Cannot merge a team with itself.")
+
+    # Caller must be the creator of the requesting team
+    req_team = (
+        supabase_admin.table("teams")
+        .select("id, created_by")
+        .eq("id", requesting_team_id)
+        .maybeSingle()
+        .execute()
+    )
+    if not req_team.data:
+        raise HTTPException(status_code=404, detail="Requesting team not found.")
+    if req_team.data["created_by"] != user_id:
+        raise HTTPException(status_code=403, detail="You are not the creator of the requesting team.")
+
+    # Target team must exist
+    target_team = (
+        supabase_admin.table("teams")
+        .select("id")
+        .eq("id", team_id)
+        .maybeSingle()
+        .execute()
+    )
+    if not target_team.data:
+        raise HTTPException(status_code=404, detail="Target team not found.")
+
+    # No duplicate pending request between these two teams
+    existing = (
+        supabase_admin.table("merge_requests")
+        .select("id")
+        .eq("requesting_team_id", requesting_team_id)
+        .eq("target_team_id", team_id)
+        .eq("status", "pending")
+        .maybeSingle()
+        .execute()
+    )
+    if existing.data:
+        raise HTTPException(status_code=409, detail="A pending merge request already exists for these teams.")
+
+    result = (
+        supabase_admin.table("merge_requests")
+        .insert({
+            "requesting_team_id": requesting_team_id,
+            "target_team_id": team_id,
+            "status": "pending",
+        })
+        .execute()
+    )
+
+    if not result.data:
+        raise HTTPException(status_code=500, detail="Failed to create merge request.")
+
+    return result.data[0]

--- a/backend/routers/teams.py
+++ b/backend/routers/teams.py
@@ -26,7 +26,7 @@ async def create_merge_request(
         supabase_admin.table("teams")
         .select("id, created_by")
         .eq("id", requesting_team_id)
-        .maybeSingle()
+        .maybe_single()
         .execute()
     )
     if not req_team.data:
@@ -39,7 +39,7 @@ async def create_merge_request(
         supabase_admin.table("teams")
         .select("id")
         .eq("id", team_id)
-        .maybeSingle()
+        .maybe_single()
         .execute()
     )
     if not target_team.data:
@@ -52,7 +52,7 @@ async def create_merge_request(
         .eq("requesting_team_id", requesting_team_id)
         .eq("target_team_id", team_id)
         .eq("status", "pending")
-        .maybeSingle()
+        .maybe_single()
         .execute()
     )
     if existing.data:

--- a/backend/tests/test_merge_requests.py
+++ b/backend/tests/test_merge_requests.py
@@ -35,7 +35,7 @@ def _chain(*args, data=None):
     m = MagicMock()
     m.select.return_value = m
     m.eq.return_value = m
-    m.maybeSingle.return_value = m
+    m.maybe_single.return_value = m
     m.insert.return_value = m
     m.execute.return_value = _make_result(data)
     return m
@@ -79,7 +79,7 @@ def test_self_merge_rejected(client):
 def test_requesting_team_not_found(client):
     with patch("routers.teams.supabase_admin") as mock_db:
         mock_db.table.return_value.select.return_value.eq.return_value \
-            .maybeSingle.return_value.execute.return_value = _make_result(None)
+            .maybe_single.return_value.execute.return_value = _make_result(None)
 
         res = _post(client)
     assert res.status_code == 404
@@ -93,7 +93,7 @@ def test_not_team_creator_forbidden(client):
         m = MagicMock()
         m.select.return_value = m
         m.eq.return_value = m
-        m.maybeSingle.return_value = m
+        m.maybe_single.return_value = m
         m.execute.return_value = _make_result(req_team_row)
         return m
 
@@ -112,7 +112,7 @@ def test_target_team_not_found(client):
         m = MagicMock()
         m.select.return_value = m
         m.eq.return_value = m
-        m.maybeSingle.return_value = m
+        m.maybe_single.return_value = m
         call_count[0] += 1
         # First call → requesting team found; second call → target team missing
         m.execute.return_value = _make_result(req_team_row if call_count[0] == 1 else None)
@@ -136,7 +136,7 @@ def test_duplicate_pending_request_rejected(client):
         m = MagicMock()
         m.select.return_value = m
         m.eq.return_value = m
-        m.maybeSingle.return_value = m
+        m.maybe_single.return_value = m
         m.execute.return_value = _make_result(next(results))
         return m
 
@@ -158,7 +158,7 @@ def test_successful_merge_request(client):
         m = MagicMock()
         m.select.return_value = m
         m.eq.return_value = m
-        m.maybeSingle.return_value = m
+        m.maybe_single.return_value = m
         m.insert.return_value = m
         call_count[0] += 1
         if call_count[0] <= 3:

--- a/backend/tests/test_merge_requests.py
+++ b/backend/tests/test_merge_requests.py
@@ -1,0 +1,178 @@
+"""
+Simple unit tests for POST /teams/{team_id}/merge-requests.
+
+Uses FastAPI's TestClient and mocks Supabase calls so no live DB is needed.
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+from fastapi.testclient import TestClient
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+REQUESTING_TEAM_ID = "aaaa0000-0000-0000-0000-000000000001"
+TARGET_TEAM_ID     = "bbbb0000-0000-0000-0000-000000000002"
+CREATOR_USER_ID    = "cccc0000-0000-0000-0000-000000000003"
+OTHER_USER_ID      = "dddd0000-0000-0000-0000-000000000004"
+
+MERGE_REQUEST_ROW = {
+    "id": "eeee0000-0000-0000-0000-000000000005",
+    "requesting_team_id": REQUESTING_TEAM_ID,
+    "target_team_id": TARGET_TEAM_ID,
+    "status": "pending",
+    "created_at": "2026-04-28T00:00:00+00:00",
+}
+
+
+def _make_result(data):
+    """Return a mock Supabase query result object."""
+    m = MagicMock()
+    m.data = data
+    return m
+
+
+def _chain(*args, data=None):
+    """Return a chainable mock that ends with .execute() -> data."""
+    m = MagicMock()
+    m.select.return_value = m
+    m.eq.return_value = m
+    m.maybeSingle.return_value = m
+    m.insert.return_value = m
+    m.execute.return_value = _make_result(data)
+    return m
+
+
+# ── App setup (import after mocks are in place) ────────────────────────────────
+
+@pytest.fixture()
+def client(monkeypatch):
+    """Build a TestClient with auth and Supabase both mocked."""
+    # Patch get_user_id so every request appears to come from CREATOR_USER_ID
+    monkeypatch.setattr("auth.get_user_id", lambda: CREATOR_USER_ID)
+
+    from main import app
+    return TestClient(app, raise_server_exceptions=True)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _post(client, target=TARGET_TEAM_ID, requesting=REQUESTING_TEAM_ID):
+    return client.post(
+        f"/teams/{target}/merge-requests",
+        json={"requesting_team_id": requesting},
+        headers={"Authorization": "Bearer fake-token"},
+    )
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────────
+
+def test_self_merge_rejected(client):
+    """Sending a merge request to your own team should return 400."""
+    res = client.post(
+        f"/teams/{REQUESTING_TEAM_ID}/merge-requests",
+        json={"requesting_team_id": REQUESTING_TEAM_ID},
+        headers={"Authorization": "Bearer fake-token"},
+    )
+    assert res.status_code == 400
+    assert "itself" in res.json()["detail"]
+
+
+def test_requesting_team_not_found(client):
+    with patch("routers.teams.supabase_admin") as mock_db:
+        mock_db.table.return_value.select.return_value.eq.return_value \
+            .maybeSingle.return_value.execute.return_value = _make_result(None)
+
+        res = _post(client)
+    assert res.status_code == 404
+    assert "Requesting team" in res.json()["detail"]
+
+
+def test_not_team_creator_forbidden(client):
+    req_team_row = {"id": REQUESTING_TEAM_ID, "created_by": OTHER_USER_ID}
+
+    def table_side_effect(name):
+        m = MagicMock()
+        m.select.return_value = m
+        m.eq.return_value = m
+        m.maybeSingle.return_value = m
+        m.execute.return_value = _make_result(req_team_row)
+        return m
+
+    with patch("routers.teams.supabase_admin") as mock_db:
+        mock_db.table.side_effect = table_side_effect
+        res = _post(client)
+    assert res.status_code == 403
+
+
+def test_target_team_not_found(client):
+    req_team_row = {"id": REQUESTING_TEAM_ID, "created_by": CREATOR_USER_ID}
+
+    call_count = [0]
+
+    def table_side_effect(name):
+        m = MagicMock()
+        m.select.return_value = m
+        m.eq.return_value = m
+        m.maybeSingle.return_value = m
+        call_count[0] += 1
+        # First call → requesting team found; second call → target team missing
+        m.execute.return_value = _make_result(req_team_row if call_count[0] == 1 else None)
+        return m
+
+    with patch("routers.teams.supabase_admin") as mock_db:
+        mock_db.table.side_effect = table_side_effect
+        res = _post(client)
+    assert res.status_code == 404
+    assert "Target team" in res.json()["detail"]
+
+
+def test_duplicate_pending_request_rejected(client):
+    req_team_row    = {"id": REQUESTING_TEAM_ID, "created_by": CREATOR_USER_ID}
+    target_team_row = {"id": TARGET_TEAM_ID}
+    existing_row    = {"id": "existing-uuid"}
+
+    results = iter([req_team_row, target_team_row, existing_row])
+
+    def table_side_effect(name):
+        m = MagicMock()
+        m.select.return_value = m
+        m.eq.return_value = m
+        m.maybeSingle.return_value = m
+        m.execute.return_value = _make_result(next(results))
+        return m
+
+    with patch("routers.teams.supabase_admin") as mock_db:
+        mock_db.table.side_effect = table_side_effect
+        res = _post(client)
+    assert res.status_code == 409
+
+
+def test_successful_merge_request(client):
+    req_team_row    = {"id": REQUESTING_TEAM_ID, "created_by": CREATOR_USER_ID}
+    target_team_row = {"id": TARGET_TEAM_ID}
+
+    results = iter([req_team_row, target_team_row, None])  # None = no existing request
+
+    call_count = [0]
+
+    def table_side_effect(name):
+        m = MagicMock()
+        m.select.return_value = m
+        m.eq.return_value = m
+        m.maybeSingle.return_value = m
+        m.insert.return_value = m
+        call_count[0] += 1
+        if call_count[0] <= 3:
+            m.execute.return_value = _make_result(next(results))
+        else:
+            m.execute.return_value = _make_result([MERGE_REQUEST_ROW])
+        return m
+
+    with patch("routers.teams.supabase_admin") as mock_db:
+        mock_db.table.side_effect = table_side_effect
+        res = _post(client)
+
+    assert res.status_code == 201
+    body = res.json()
+    assert body["requesting_team_id"] == REQUESTING_TEAM_ID
+    assert body["target_team_id"]     == TARGET_TEAM_ID
+    assert body["status"]             == "pending"

--- a/backend/tests/test_merge_requests.py
+++ b/backend/tests/test_merge_requests.py
@@ -24,36 +24,30 @@ MERGE_REQUEST_ROW = {
 
 
 def _make_result(data):
-    """Return a mock Supabase query result object."""
     m = MagicMock()
     m.data = data
     return m
 
 
-def _chain(*args, data=None):
-    """Return a chainable mock that ends with .execute() -> data."""
+def _chainable_table(data):
+    """Return a mock table that chains select/eq/limit/insert and returns data on execute()."""
     m = MagicMock()
     m.select.return_value = m
     m.eq.return_value = m
-    m.maybe_single.return_value = m
+    m.limit.return_value = m
     m.insert.return_value = m
     m.execute.return_value = _make_result(data)
     return m
 
 
-# ── App setup (import after mocks are in place) ────────────────────────────────
+# ── App setup ─────────────────────────────────────────────────────────────────
 
 @pytest.fixture()
 def client(monkeypatch):
-    """Build a TestClient with auth and Supabase both mocked."""
-    # Patch get_user_id so every request appears to come from CREATOR_USER_ID
     monkeypatch.setattr("auth.get_user_id", lambda: CREATOR_USER_ID)
-
     from main import app
     return TestClient(app, raise_server_exceptions=True)
 
-
-# ── Helpers ────────────────────────────────────────────────────────────────────
 
 def _post(client, target=TARGET_TEAM_ID, requesting=REQUESTING_TEAM_ID):
     return client.post(
@@ -66,7 +60,6 @@ def _post(client, target=TARGET_TEAM_ID, requesting=REQUESTING_TEAM_ID):
 # ── Tests ──────────────────────────────────────────────────────────────────────
 
 def test_self_merge_rejected(client):
-    """Sending a merge request to your own team should return 400."""
     res = client.post(
         f"/teams/{REQUESTING_TEAM_ID}/merge-requests",
         json={"requesting_team_id": REQUESTING_TEAM_ID},
@@ -78,9 +71,7 @@ def test_self_merge_rejected(client):
 
 def test_requesting_team_not_found(client):
     with patch("routers.teams.supabase_admin") as mock_db:
-        mock_db.table.return_value.select.return_value.eq.return_value \
-            .maybe_single.return_value.execute.return_value = _make_result(None)
-
+        mock_db.table.return_value = _chainable_table([])
         res = _post(client)
     assert res.status_code == 404
     assert "Requesting team" in res.json()["detail"]
@@ -89,33 +80,18 @@ def test_requesting_team_not_found(client):
 def test_not_team_creator_forbidden(client):
     req_team_row = {"id": REQUESTING_TEAM_ID, "created_by": OTHER_USER_ID}
 
-    def table_side_effect(name):
-        m = MagicMock()
-        m.select.return_value = m
-        m.eq.return_value = m
-        m.maybe_single.return_value = m
-        m.execute.return_value = _make_result(req_team_row)
-        return m
-
     with patch("routers.teams.supabase_admin") as mock_db:
-        mock_db.table.side_effect = table_side_effect
+        mock_db.table.return_value = _chainable_table([req_team_row])
         res = _post(client)
     assert res.status_code == 403
 
 
 def test_target_team_not_found(client):
     req_team_row = {"id": REQUESTING_TEAM_ID, "created_by": CREATOR_USER_ID}
-
-    call_count = [0]
+    results = iter([[req_team_row], []])
 
     def table_side_effect(name):
-        m = MagicMock()
-        m.select.return_value = m
-        m.eq.return_value = m
-        m.maybe_single.return_value = m
-        call_count[0] += 1
-        # First call → requesting team found; second call → target team missing
-        m.execute.return_value = _make_result(req_team_row if call_count[0] == 1 else None)
+        m = _chainable_table(next(results))
         return m
 
     with patch("routers.teams.supabase_admin") as mock_db:
@@ -129,19 +105,10 @@ def test_duplicate_pending_request_rejected(client):
     req_team_row    = {"id": REQUESTING_TEAM_ID, "created_by": CREATOR_USER_ID}
     target_team_row = {"id": TARGET_TEAM_ID}
     existing_row    = {"id": "existing-uuid"}
-
-    results = iter([req_team_row, target_team_row, existing_row])
-
-    def table_side_effect(name):
-        m = MagicMock()
-        m.select.return_value = m
-        m.eq.return_value = m
-        m.maybe_single.return_value = m
-        m.execute.return_value = _make_result(next(results))
-        return m
+    results = iter([[req_team_row], [target_team_row], [existing_row]])
 
     with patch("routers.teams.supabase_admin") as mock_db:
-        mock_db.table.side_effect = table_side_effect
+        mock_db.table.side_effect = lambda _: _chainable_table(next(results))
         res = _post(client)
     assert res.status_code == 409
 
@@ -149,26 +116,10 @@ def test_duplicate_pending_request_rejected(client):
 def test_successful_merge_request(client):
     req_team_row    = {"id": REQUESTING_TEAM_ID, "created_by": CREATOR_USER_ID}
     target_team_row = {"id": TARGET_TEAM_ID}
-
-    results = iter([req_team_row, target_team_row, None])  # None = no existing request
-
-    call_count = [0]
-
-    def table_side_effect(name):
-        m = MagicMock()
-        m.select.return_value = m
-        m.eq.return_value = m
-        m.maybe_single.return_value = m
-        m.insert.return_value = m
-        call_count[0] += 1
-        if call_count[0] <= 3:
-            m.execute.return_value = _make_result(next(results))
-        else:
-            m.execute.return_value = _make_result([MERGE_REQUEST_ROW])
-        return m
+    results = iter([[req_team_row], [target_team_row], [], [MERGE_REQUEST_ROW]])
 
     with patch("routers.teams.supabase_admin") as mock_db:
-        mock_db.table.side_effect = table_side_effect
+        mock_db.table.side_effect = lambda _: _chainable_table(next(results))
         res = _post(client)
 
     assert res.status_code == 201

--- a/frontend/src/pages/TeamDetail.jsx
+++ b/frontend/src/pages/TeamDetail.jsx
@@ -14,6 +14,7 @@ import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import NavigationSidebar from '../components/NavigationSidebar';
 import { getClient } from '../lib/supabase';
 import { useAuth } from '../context/AuthContext';
+import { api } from '../api/client';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -158,10 +159,10 @@ function MergeRequestCard({ request, currentMemberCount, maxSize, onApprove, onR
 
 // ── Data fetching ─────────────────────────────────────────────────────────────
 
-async function fetchTeamDetail(teamId) {
+async function fetchTeamDetail(teamId, userId) {
   const sb = getClient();
 
-  // Team + survey title
+  // Team + survey id + title
   const { data: team, error: teamErr } = await sb
     .from('teams')
     .select('*, surveys(title)')
@@ -185,7 +186,22 @@ async function fetchTeamDetail(teamId) {
     .eq('status', 'pending');
   if (mergeErr) throw mergeErr;
 
-  return { team, members: members ?? [], mergeRequests: mergeRequests ?? [] };
+  // Find the current user's team in the same survey (to use as requesting_team_id)
+  let myTeamId = null;
+  if (userId && team?.survey_id) {
+    const { data: myMembership } = await sb
+      .from('team_members')
+      .select('team_id, teams!inner(survey_id, created_by)')
+      .eq('user_id', userId)
+      .eq('status', 'approved')
+      .eq('teams.survey_id', team.survey_id)
+      .maybeSingle();
+    if (myMembership) {
+      myTeamId = myMembership.team_id;
+    }
+  }
+
+  return { team, members: members ?? [], mergeRequests: mergeRequests ?? [], myTeamId };
 }
 
 // ── Main component ────────────────────────────────────────────────────────────
@@ -195,9 +211,10 @@ export default function TeamDetail() {
   const navigate = useNavigate();
   const { user } = useAuth();
 
-  const [data, setData] = useState(null);       // { team, members, mergeRequests }
+  const [data, setData] = useState(null);       // { team, members, mergeRequests, myTeamId }
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [mergeError, setMergeError] = useState(null);
 
   // View mode: 'owner' | 'visitor' | 'pending'
   // Determined after data loads based on whether the current user created the team.
@@ -206,7 +223,7 @@ export default function TeamDetail() {
   useEffect(() => {
     if (!teamId) return;
     setLoading(true);
-    fetchTeamDetail(teamId)
+    fetchTeamDetail(teamId, user?.id)
       .then(result => {
         setData(result);
         const isOwner = result.team.created_by === user?.id;
@@ -247,7 +264,22 @@ export default function TeamDetail() {
   const capacityPct = (members.length / team.max_size) * 100;
   const isOwner = viewMode === 'owner';
 
-  // ── Merge-request handlers (optimistic UI; real API calls go here) ──────────
+  // ── Merge-request handlers ────────────────────────────────────────────────
+
+  async function handleSendMergeRequest() {
+    setMergeError(null);
+    const myTeamId = data?.myTeamId;
+    if (!myTeamId) {
+      setMergeError('You must be on a team in this survey to send a merge request.');
+      return;
+    }
+    try {
+      await api.post(`/teams/${teamId}/merge-requests`, { requesting_team_id: myTeamId });
+      setViewMode('pending');
+    } catch (err) {
+      setMergeError(err.message ?? 'Failed to send merge request.');
+    }
+  }
 
   function handleApproveMerge(reqId) {
     // TODO: POST /teams/merge-requests/{reqId}/approve
@@ -331,10 +363,13 @@ export default function TeamDetail() {
         )}
 
         {viewMode === 'visitor' && (
-          <Stack direction="row" spacing={1.25} sx={{ mb: 2 }}>
-            <Button variant="contained" onClick={() => setViewMode('pending')}>
-              Request to merge teams
-            </Button>
+          <Stack spacing={1} sx={{ mb: 2 }}>
+            <Stack direction="row" spacing={1.25}>
+              <Button variant="contained" onClick={handleSendMergeRequest}>
+                Request to merge teams
+              </Button>
+            </Stack>
+            {mergeError && <Alert severity="error" sx={{ fontSize: 13 }}>{mergeError}</Alert>}
           </Stack>
         )}
 


### PR DESCRIPTION
- Adds `POST /teams/{team_id}/merge-requests` endpoint
     -  auth required, caller must be `created_by` of the requesting team
- Prevents self-merging, wrong creators, missing teams, and duplicate pending requests
- Wires up the "Request to merge teams" button in `TeamDetail.jsx` to call the real API
- Adds 6 pytest unit tests covering all error branches 

## Screenshots
<img width="633" height="466" alt="image" src="https://github.com/user-attachments/assets/e869a6bc-4583-42c2-8dc3-eb53e5976b1e" />
Page to make a merge request.

---
<img width="636" height="735" alt="image" src="https://github.com/user-attachments/assets/61922b19-06aa-4c89-9e04-9ef1c3a264b8" />
Example of a pending merge request. Approving/merging a request is a TODO feature requiring a new endpoint.

---

<img width="1359" height="210" alt="image" src="https://github.com/user-attachments/assets/a004b71d-4938-4380-9dfb-c651c817ab8e" />
This is an example of a merge request on the database.
