### PR TITLE
Approving and Rejecting Team Merge Requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,11 @@ npm run dev
 The app will be available at `http://localhost:5173`.
 
 ---
+
+### 4. Run the tests
+
+```bash
+cd backend
+uv run pytest tests/ -v
+```
+

--- a/backend/routers/teams.py
+++ b/backend/routers/teams.py
@@ -72,3 +72,124 @@ async def create_merge_request(
         raise HTTPException(status_code=500, detail="Failed to create merge request.")
 
     return result.data[0]
+
+
+def _get_pending_request(rid: str, team_id: str):
+    """Fetch a pending merge request and verify it targets team_id."""
+    res = (
+        supabase_admin.table("merge_requests")
+        .select("*")
+        .eq("id", rid)
+        .limit(1)
+        .execute()
+    )
+    if not res.data:
+        raise HTTPException(status_code=404, detail="Merge request not found.")
+    mr = res.data[0]
+    if mr["target_team_id"] != team_id:
+        raise HTTPException(status_code=404, detail="Merge request not found.")
+    if mr["status"] != "pending":
+        raise HTTPException(status_code=409, detail="Merge request is no longer pending.")
+    return mr
+
+
+def _assert_target_owner(team_id: str, user_id: str):
+    """Raise 403 unless user_id is the creator of team_id."""
+    res = (
+        supabase_admin.table("teams")
+        .select("created_by")
+        .eq("id", team_id)
+        .limit(1)
+        .execute()
+    )
+    if not res.data:
+        raise HTTPException(status_code=404, detail="Target team not found.")
+    if res.data[0]["created_by"] != user_id:
+        raise HTTPException(status_code=403, detail="You are not the creator of the target team.")
+
+
+@router.post(
+    "/{team_id}/merge-requests/{rid}/approve",
+    response_model=MergeRequestResponse,
+)
+async def approve_merge_request(
+    team_id: str,
+    rid: str,
+    user_id: str = Depends(get_user_id),
+):
+    _assert_target_owner(team_id, user_id)
+    mr = _get_pending_request(rid, team_id)
+    requesting_team_id = mr["requesting_team_id"]
+
+    # Guard: combined size must not exceed max_size
+    target = (
+        supabase_admin.table("teams")
+        .select("max_size")
+        .eq("id", team_id)
+        .limit(1)
+        .execute()
+    )
+    max_size = target.data[0]["max_size"]
+
+    target_members = (
+        supabase_admin.table("team_members")
+        .select("user_id")
+        .eq("team_id", team_id)
+        .eq("status", "approved")
+        .execute()
+    )
+    requesting_members = (
+        supabase_admin.table("team_members")
+        .select("user_id")
+        .eq("team_id", requesting_team_id)
+        .eq("status", "approved")
+        .execute()
+    )
+    new_total = len(target_members.data) + len(requesting_members.data)
+    if new_total > max_size:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Merge would exceed max size of {max_size} ({new_total} members).",
+        )
+
+    # Move all members of requesting team into target team
+    supabase_admin.table("team_members").update({"team_id": team_id}).eq(
+        "team_id", requesting_team_id
+    ).execute()
+
+    # Mark requesting team as merged
+    supabase_admin.table("teams").update({"merged_into": team_id}).eq(
+        "id", requesting_team_id
+    ).execute()
+
+    # Update merge request status
+    updated = (
+        supabase_admin.table("merge_requests")
+        .update({"status": "approved"})
+        .eq("id", rid)
+        .execute()
+    )
+
+    return updated.data[0]
+
+
+@router.post(
+    "/{team_id}/merge-requests/{rid}/reject",
+    response_model=MergeRequestResponse,
+)
+async def reject_merge_request(
+    team_id: str,
+    rid: str,
+    user_id: str = Depends(get_user_id),
+):
+    _assert_target_owner(team_id, user_id)
+    _get_pending_request(rid, team_id)
+
+    updated = (
+        supabase_admin.table("merge_requests")
+        .update({"status": "rejected"})
+        .eq("id", rid)
+        .execute()
+    )
+
+    return updated.data[0]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,10 @@
+import os
+import sys
+
+# Ensure the backend root is on the path regardless of where pytest is invoked from
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+# Provide dummy env vars so pydantic-settings doesn't fail on import
+os.environ.setdefault("SUPABASE_URL", "https://test.supabase.co")
+os.environ.setdefault("SUPABASE_PUBLISHABLE_KEY", "test-publishable-key")
+os.environ.setdefault("SUPABASE_SECRET_KEY", "test-secret-key")

--- a/backend/tests/test_merge_requests.py
+++ b/backend/tests/test_merge_requests.py
@@ -1,5 +1,8 @@
 """
-Simple unit tests for POST /teams/{team_id}/merge-requests.
+Simple unit tests for the merge-request endpoints:
+  POST /teams/{team_id}/merge-requests
+  POST /teams/{team_id}/merge-requests/{rid}/approve
+  POST /teams/{team_id}/merge-requests/{rid}/reject
 
 Uses FastAPI's TestClient and mocks Supabase calls so no live DB is needed.
 """
@@ -30,12 +33,13 @@ def _make_result(data):
 
 
 def _chainable_table(data):
-    """Return a mock table that chains select/eq/limit/insert and returns data on execute()."""
+    """Return a mock table that chains select/eq/limit/insert/update and returns data on execute()."""
     m = MagicMock()
     m.select.return_value = m
     m.eq.return_value = m
     m.limit.return_value = m
     m.insert.return_value = m
+    m.update.return_value = m
     m.execute.return_value = _make_result(data)
     return m
 
@@ -127,3 +131,113 @@ def test_successful_merge_request(client):
     assert body["requesting_team_id"] == REQUESTING_TEAM_ID
     assert body["target_team_id"]     == TARGET_TEAM_ID
     assert body["status"]             == "pending"
+
+
+MERGE_REQUEST_ID = MERGE_REQUEST_ROW["id"]
+
+# ── Approve / Reject helpers ───────────────────────────────────────────────────
+
+def _approve(client, team_id=TARGET_TEAM_ID, rid=MERGE_REQUEST_ID):
+    return client.post(
+        f"/teams/{team_id}/merge-requests/{rid}/approve",
+        headers={"Authorization": "Bearer fake-token"},
+    )
+
+def _reject(client, team_id=TARGET_TEAM_ID, rid=MERGE_REQUEST_ID):
+    return client.post(
+        f"/teams/{team_id}/merge-requests/{rid}/reject",
+        headers={"Authorization": "Bearer fake-token"},
+    )
+
+def _approved_row():
+    return {**MERGE_REQUEST_ROW, "status": "approved"}
+
+def _rejected_row():
+    return {**MERGE_REQUEST_ROW, "status": "rejected"}
+
+
+# ── Approve tests ─────────────────────────────────────────────────────────────
+
+def test_approve_not_target_owner_forbidden(client):
+    # _assert_target_owner: target team exists but belongs to someone else
+    target_row = {"created_by": OTHER_USER_ID}
+    with patch("routers.teams.supabase_admin") as mock_db:
+        mock_db.table.side_effect = lambda _: _chainable_table([target_row])
+        res = _approve(client)
+    assert res.status_code == 403
+
+
+def test_approve_merge_request_not_found(client):
+    target_row = {"created_by": CREATOR_USER_ID}
+    results = iter([[target_row], []])  # owner ok, then MR missing
+    with patch("routers.teams.supabase_admin") as mock_db:
+        mock_db.table.side_effect = lambda _: _chainable_table(next(results))
+        res = _approve(client)
+    assert res.status_code == 404
+
+
+def test_approve_exceeds_max_size(client):
+    target_row = {"created_by": CREATOR_USER_ID}
+    pending_mr = {**MERGE_REQUEST_ROW, "status": "pending"}
+    target_team_size = {"max_size": 2}
+    # 2 existing members + 1 requesting member = 3 > max 2
+    two_members  = [{"user_id": "u1"}, {"user_id": "u2"}]
+    one_member   = [{"user_id": "u3"}]
+    results = iter([[target_row], [pending_mr], [target_team_size], two_members, one_member])
+    with patch("routers.teams.supabase_admin") as mock_db:
+        mock_db.table.side_effect = lambda _: _chainable_table(next(results))
+        res = _approve(client)
+    assert res.status_code == 409
+    assert "max size" in res.json()["detail"]
+
+
+def test_approve_success(client):
+    target_row       = {"created_by": CREATOR_USER_ID}
+    pending_mr       = {**MERGE_REQUEST_ROW, "status": "pending"}
+    target_team_size = {"max_size": 4}
+    one_member       = [{"user_id": "u1"}]
+    one_member2      = [{"user_id": "u2"}]
+    # table() is called 8 times: owner check, MR fetch, max_size, 2x members,
+    # move members (update), mark merged (update), update MR status (update)
+    results = iter([
+        [target_row], [pending_mr], [target_team_size], one_member, one_member2,
+        [], [], [_approved_row()],
+    ])
+
+    with patch("routers.teams.supabase_admin") as mock_db:
+        mock_db.table.side_effect = lambda _: _chainable_table(next(results))
+        res = _approve(client)
+
+    assert res.status_code == 200
+    assert res.json()["status"] == "approved"
+
+
+# ── Reject tests ──────────────────────────────────────────────────────────────
+
+def test_reject_not_target_owner_forbidden(client):
+    target_row = {"created_by": OTHER_USER_ID}
+    with patch("routers.teams.supabase_admin") as mock_db:
+        mock_db.table.side_effect = lambda _: _chainable_table([target_row])
+        res = _reject(client)
+    assert res.status_code == 403
+
+
+def test_reject_merge_request_not_found(client):
+    target_row = {"created_by": CREATOR_USER_ID}
+    results = iter([[target_row], []])
+    with patch("routers.teams.supabase_admin") as mock_db:
+        mock_db.table.side_effect = lambda _: _chainable_table(next(results))
+        res = _reject(client)
+    assert res.status_code == 404
+
+
+def test_reject_success(client):
+    target_row = {"created_by": CREATOR_USER_ID}
+    pending_mr = {**MERGE_REQUEST_ROW, "status": "pending"}
+    # table() called 3 times: owner check, MR fetch, update MR status
+    results = iter([[target_row], [pending_mr], [_rejected_row()]])
+    with patch("routers.teams.supabase_admin") as mock_db:
+        mock_db.table.side_effect = lambda _: _chainable_table(next(results))
+        res = _reject(client)
+    assert res.status_code == 200
+    assert res.json()["status"] == "rejected"

--- a/frontend/src/pages/TeamBrowser.jsx
+++ b/frontend/src/pages/TeamBrowser.jsx
@@ -23,6 +23,7 @@ import GroupsOutlinedIcon from '@mui/icons-material/GroupsOutlined';
 import NavigationSidebar from '../components/NavigationSidebar';
 import { getClient } from '../lib/supabase';
 import { api } from '../api/client';
+import { useAuth } from '../context/AuthContext';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -173,85 +174,6 @@ function TeamCard({ team, isMyTeam, matchPct, onView, onRequestMerge }) {
   );
 }
 
-const MOCK_RECOMMENDATIONS = [
-  {
-    id: 'rec-1',
-    type: 'person',
-    name: 'Jordan Kim',
-    members: [
-      { id: 'u-jk', name: 'Jordan Kim', school: 'Amherst College', major: 'Computer Science', gradYear: 2027 },
-    ],
-    maxSize: 4,
-    description: 'Looking for a team for the hackathon. Strong in full-stack dev and ML. Night-owl coder, prefer async communication.',
-    matchPct: 94,
-    spotsLeft: 3,
-  },
-  {
-    id: 'rec-2',
-    type: 'team',
-    name: 'The Debug Ducks',
-    members: [
-      { id: 'u-ms', name: 'Maya Singh', school: 'Hampshire College', major: 'Data Science', gradYear: 2026 },
-      { id: 'u-lo', name: 'Leo Ortega', school: 'Mount Holyoke', major: 'Statistics', gradYear: 2027 },
-    ],
-    maxSize: 4,
-    description: 'Working on a data visualization project for public health. Need 2 more members with frontend or design skills.',
-    matchPct: 87,
-    spotsLeft: 2,
-  },
-  {
-    id: 'rec-3',
-    type: 'person',
-    name: 'Sam Rivera',
-    members: [
-      { id: 'u-sr', name: 'Sam Rivera', school: 'Smith College', major: 'UI/UX Design', gradYear: 2026 },
-    ],
-    maxSize: 4,
-    description: 'Designer looking for an engineering team. Experienced with Figma and user research. Passionate about accessibility.',
-    matchPct: 79,
-    spotsLeft: 3,
-  },
-  {
-    id: 'rec-4',
-    type: 'team',
-    name: 'Circuit Breakers',
-    members: [
-      { id: 'u-ec', name: 'Ethan Cole', school: 'Amherst College', major: 'Physics', gradYear: 2025 },
-      { id: 'u-pw', name: 'Priya Wen', school: 'UMass Amherst', major: 'Electrical Engineering', gradYear: 2026 },
-      { id: 'u-nb', name: 'Noah Brooks', school: 'UMass Amherst', major: 'Computer Engineering', gradYear: 2027 },
-    ],
-    maxSize: 5,
-    description: 'Hardware + software team building an IoT sensor platform. Strong embedded systems background.',
-    matchPct: 68,
-    spotsLeft: 2,
-  },
-  {
-    id: 'rec-5',
-    type: 'person',
-    name: 'Ava Thompson',
-    members: [
-      { id: 'u-at', name: 'Ava Thompson', school: 'Hampshire College', major: 'Cognitive Science', gradYear: 2027 },
-    ],
-    maxSize: 4,
-    description: 'Interested in NLP and conversational AI. Also enjoys product management and bridging the gap between users and devs.',
-    matchPct: 61,
-    spotsLeft: 3,
-  },
-  {
-    id: 'rec-6',
-    type: 'team',
-    name: 'Green Stack',
-    members: [
-      { id: 'u-fw', name: 'Fatima Wali', school: 'Mount Holyoke', major: 'Environmental Science', gradYear: 2026 },
-      { id: 'u-cl', name: 'Chris Lau', school: 'Amherst College', major: 'Computer Science', gradYear: 2026 },
-    ],
-    maxSize: 4,
-    description: 'Building a sustainability tracking app. Combining env science domain knowledge with tech.',
-    matchPct: 53,
-    spotsLeft: 2,
-  },
-];
-
 // Returns a MUI color string based on a percentage value
 function matchColor(pct) {
   if (pct >= 85) return 'success';
@@ -382,11 +304,9 @@ function RecommendedCard({ rec, rank, onAction }) {
 
 // ── Main component ────────────────────────────────────────────────────────────
 
-// For demo: treat the first team as "my team" (no real auth in demo mode)
-const DEMO_MY_TEAM_INDEX = 0;
-
 export default function TeamBrowser() {
   const navigate = useNavigate();
+  const { user } = useAuth();
 
   const [data, setData]         = useState(null);
   const [loading, setLoading]   = useState(true);
@@ -414,7 +334,9 @@ export default function TeamBrowser() {
       .finally(() => setRecLoading(false));
   }, [data?.survey?.id]);
 
-  const myTeam = data?.teams[DEMO_MY_TEAM_INDEX] ?? null;
+  const myTeam = data?.teams.find(t =>
+    t.team_members.some(m => m.user_id === user?.id)
+  ) ?? null;
 
   const filtered = useMemo(() => {
     if (!data) return [];

--- a/frontend/src/pages/TeamDetail.jsx
+++ b/frontend/src/pages/TeamDetail.jsx
@@ -281,20 +281,28 @@ export default function TeamDetail() {
     }
   }
 
-  function handleApproveMerge(reqId) {
-    // TODO: POST /teams/merge-requests/{reqId}/approve
-    setData(prev => ({
-      ...prev,
-      mergeRequests: prev.mergeRequests.filter(r => r.id !== reqId),
-    }));
+  async function handleApproveMerge(reqId) {
+    try {
+      await api.post(`/teams/${teamId}/merge-requests/${reqId}/approve`);
+      setData(prev => ({
+        ...prev,
+        mergeRequests: prev.mergeRequests.filter(r => r.id !== reqId),
+      }));
+    } catch (err) {
+      setMergeError(err.message ?? 'Failed to approve merge request.');
+    }
   }
 
-  function handleRejectMerge(reqId) {
-    // TODO: POST /teams/merge-requests/{reqId}/reject
-    setData(prev => ({
-      ...prev,
-      mergeRequests: prev.mergeRequests.filter(r => r.id !== reqId),
-    }));
+  async function handleRejectMerge(reqId) {
+    try {
+      await api.post(`/teams/${teamId}/merge-requests/${reqId}/reject`);
+      setData(prev => ({
+        ...prev,
+        mergeRequests: prev.mergeRequests.filter(r => r.id !== reqId),
+      }));
+    } catch (err) {
+      setMergeError(err.message ?? 'Failed to reject merge request.');
+    }
   }
 
   // ── Render ──────────────────────────────────────────────────────────────────
@@ -403,6 +411,8 @@ export default function TeamDetail() {
                 {mergeRequests.length} pending
               </Typography>
             </Box>
+
+            {mergeError && <Alert severity="error" sx={{ fontSize: 13, mb: 1.5 }}>{mergeError}</Alert>}
 
             {mergeRequests.length === 0 ? (
               <Typography variant="body2" color="text.disabled" textAlign="center" py={2}>


### PR DESCRIPTION
- Adds `POST /teams/{team_id}/merge-requests/{rid}/approve` and `.../reject` endpoints
- Caller must be `created_by` of the target team; approve guards against exceeding `max_size`
- On approve: members are moved to the target team and the requesting team is marked `merged_into`
- Wires the approve/reject buttons in `TeamDetail.jsx` to the real API with inline error display
- Adds 7 new tests 

## Test cases

- [x] As target team owner, approve a pending request, requesting team's members should appear in your team
- [X] Approve should fail if it would exceed `max_size`
- [X] Reject should flip the request status without moving any members