### PR TITLE
Feature/search and filter

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -4,6 +4,7 @@ from routers.auth import router as auth_router
 from routers.recommendations import router as recommendations_router
 from routers.teams import router as teams_router
 from routers.surveys import router as surveys_router
+from routers.search import router as search_router
 
 app = FastAPI(
     title="Common Ground API",
@@ -26,6 +27,7 @@ app.include_router(auth_router)
 app.include_router(recommendations_router)
 app.include_router(teams_router)
 app.include_router(surveys_router)
+app.include_router(search_router)
 
 
 @app.get("/health", tags=["meta"])

--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -141,3 +141,27 @@ class MergeRequestResponse(BaseModel):
     target_team_id: str
     status: str
     created_at: datetime
+
+
+# ── Search ────────────────────────────────────────────────────────────────────
+
+class SearchMemberProfile(BaseModel):
+    user_id: str
+    full_name: Optional[str]
+
+
+class TeamSearchResult(BaseModel):
+    id: str
+    name: str
+    description: Optional[str]
+    max_size: int
+    created_by: str
+    team_members: list[SearchMemberProfile]
+
+
+class TeamSearchResponse(BaseModel):
+    results: list[TeamSearchResult]
+    total: int
+    page: int
+
+

--- a/backend/routers/search.py
+++ b/backend/routers/search.py
@@ -1,3 +1,107 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException, Query
+from auth import get_user_id
+from db import supabase
+from models.schemas import (
+    TeamSearchResponse, TeamSearchResult, SearchMemberProfile,
+)
 
 router = APIRouter(prefix="/search", tags=["search"])
+
+
+@router.get("/teams", response_model=TeamSearchResponse)
+async def search_teams(
+    survey_id: str = Query(...),
+    name: str | None = Query(None),
+    has_space: bool | None = Query(None),
+    sort_by: str | None = Query(None, pattern="^(name|spots)$"),
+    sort_order: str = Query("asc", pattern="^(asc|desc)$"),
+    filter_question_id: str | None = Query(None),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    current_user_id: str = Depends(get_user_id),
+):
+    # Resolve which user IDs share the current user's answer to the filtered question
+    matching_user_ids: set[str] | None = None
+    if filter_question_id:
+        my_ans = (
+            supabase.table("survey_responses")
+            .select("answer_option_id, answer_text")
+            .eq("user_id", current_user_id)
+            .eq("question_id", filter_question_id)
+            .maybe_single()
+            .execute()
+        )
+        if my_ans and my_ans.data:
+            ans = my_ans.data
+            same_q = (
+                supabase.table("survey_responses")
+                .select("user_id")
+                .eq("question_id", filter_question_id)
+                .neq("user_id", current_user_id)
+            )
+            if ans.get("answer_option_id"):
+                same_q = same_q.eq("answer_option_id", ans["answer_option_id"])
+            elif ans.get("answer_text"):
+                same_q = same_q.eq("answer_text", ans["answer_text"])
+            else:
+                same_q = None
+
+            if same_q is not None:
+                same_res = same_q.execute()
+                matching_user_ids = {r["user_id"] for r in (same_res.data or [])}
+            else:
+                matching_user_ids = set()
+
+    query = (
+        supabase.table("teams")
+        .select("id, name, description, max_size, created_by, team_members(user_id, status, profiles(full_name))")
+        .eq("survey_id", survey_id)
+        .is_("merged_into", None)
+    )
+    if name:
+        query = query.ilike("name", f"%{name}%")
+
+    result = query.execute()
+    if result.data is None:
+        raise HTTPException(status_code=500, detail="Failed to fetch teams")
+
+    teams = []
+    for t in result.data:
+        approved = [
+            m for m in (t.get("team_members") or [])
+            if m.get("status") == "approved"
+        ]
+        if has_space is True and len(approved) >= t["max_size"]:
+            continue
+        if matching_user_ids is not None:
+            member_ids = {m["user_id"] for m in approved}
+            if not member_ids & matching_user_ids:
+                continue
+        teams.append(
+            TeamSearchResult(
+                id=t["id"],
+                name=t["name"],
+                description=t.get("description"),
+                max_size=t["max_size"],
+                created_by=t["created_by"],
+                team_members=[
+                    SearchMemberProfile(
+                        user_id=m["user_id"],
+                        full_name=(m.get("profiles") or {}).get("full_name"),
+                    )
+                    for m in approved
+                ],
+            )
+        )
+
+    desc = sort_order == "desc"
+    if sort_by == "name":
+        teams.sort(key=lambda t: t.name.lower(), reverse=desc)
+    elif sort_by == "spots":
+        teams.sort(key=lambda t: t.max_size - len(t.team_members), reverse=desc)
+
+    total = len(teams)
+    offset = (page - 1) * page_size
+    page_slice = teams[offset : offset + page_size]
+
+    return TeamSearchResponse(results=page_slice, total=total, page=page)

--- a/frontend/src/pages/TeamBrowser.jsx
+++ b/frontend/src/pages/TeamBrowser.jsx
@@ -11,6 +11,10 @@ import TextField from '@mui/material/TextField';
 import InputAdornment from '@mui/material/InputAdornment';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Checkbox from '@mui/material/Checkbox';
+import Select from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
 import LinearProgress from '@mui/material/LinearProgress';
 import CircularProgress from '@mui/material/CircularProgress';
 import Alert from '@mui/material/Alert';
@@ -46,7 +50,7 @@ function daysLeft(deadline) {
 
 // ── Data fetching ─────────────────────────────────────────────────────────────
 
-async function fetchBrowserData(activeSurveyId) {
+async function fetchBrowserData(activeSurveyId, { sortBy, sortOrder, filterQuestionId } = {}) {
   const sb = getClient();
 
   let survey;
@@ -74,21 +78,20 @@ async function fetchBrowserData(activeSurveyId) {
 
   if (!survey) throw new Error('No surveys found. Make sure the seed script has been run and RLS allows reads.');
 
-  // All non-merged teams for this survey with approved members + profiles
-  const { data: teams, error: tErr } = await sb
-    .from('teams')
-    .select('id, name, description, max_size, created_by, team_members(user_id, status, profiles(full_name))')
+  const { data: questions } = await sb
+    .from('questions')
+    .select('id, prompt, question_type')
     .eq('survey_id', survey.id)
-    .is('merged_into', null);
-  if (tErr) throw tErr;
+    .order('order_index');
 
-  // Filter to approved members only
-  const normalised = (teams ?? []).map(t => ({
-    ...t,
-    team_members: (t.team_members ?? []).filter(m => m.status === 'approved'),
-  }));
+  const params = new URLSearchParams({ survey_id: survey.id, page_size: 100 });
+  if (sortBy) params.set('sort_by', sortBy);
+  if (sortOrder) params.set('sort_order', sortOrder);
+  if (filterQuestionId) params.set('filter_question_id', filterQuestionId);
 
-  return { survey, teams: normalised };
+  const searchRes = await api.get(`/search/teams?${params}`);
+
+  return { survey, teams: searchRes.results, questions: questions ?? [] };
 }
 
 // ── Team card ─────────────────────────────────────────────────────────────────
@@ -327,20 +330,26 @@ export default function TeamBrowser() {
   const [data, setData]         = useState(null);
   const [loading, setLoading]   = useState(true);
   const [error, setError]       = useState(null);
-  const [tab, setTab]           = useState('all');
-  const [search, setSearch]     = useState('');
-  const [openOnly, setOpenOnly] = useState(false);
-  const [recFilter, setRecFilter] = useState('all'); // 'all' | 'person' | 'team'
+  const [tab, setTab]                     = useState('all');
+  const [search, setSearch]               = useState('');
+  const [openOnly, setOpenOnly]           = useState(false);
+  const [minSize, setMinSize]             = useState('');
+  const [maxSize, setMaxSize]             = useState('');
+  const [sortKey, setSortKey]             = useState('');  // '' | 'name_asc' | 'name_desc' | 'spots_asc' | 'spots_desc'
+  const [filterQuestionId, setFilterQuestionId] = useState('');
+  const [recFilter, setRecFilter]         = useState('all'); // 'all' | 'person' | 'team'
   const [recommendations, setRecommendations] = useState([]);
   const [recLoading, setRecLoading] = useState(false);
 
+  const [sortBy, sortOrder] = sortKey ? sortKey.split('_') : ['', 'asc'];
+
   useEffect(() => {
     setLoading(true);
-    fetchBrowserData(activeSurvey?.id ?? null)
+    fetchBrowserData(activeSurvey?.id ?? null, { sortBy, sortOrder, filterQuestionId })
       .then(setData)
       .catch(err => setError(err.message ?? 'Failed to load teams'))
       .finally(() => setLoading(false));
-  }, [activeSurvey?.id]);
+  }, [activeSurvey?.id, sortKey, filterQuestionId]);
 
   useEffect(() => {
     if (!data?.survey?.id) return;
@@ -357,12 +366,17 @@ export default function TeamBrowser() {
 
   const filtered = useMemo(() => {
     if (!data) return [];
+    const min = minSize !== '' ? Number(minSize) : null;
+    const max = maxSize !== '' ? Number(maxSize) : null;
     return data.teams.filter(t => {
+      const count = t.team_members.length;
       const matchesSearch = t.name.toLowerCase().includes(search.toLowerCase());
-      const matchesOpen   = !openOnly || (t.max_size - t.team_members.length) > 0;
-      return matchesSearch && matchesOpen;
+      const matchesOpen   = !openOnly || (t.max_size - count) > 0;
+      const matchesMin    = min === null || count >= min;
+      const matchesMax    = max === null || count <= max;
+      return matchesSearch && matchesOpen && matchesMin && matchesMax;
     });
-  }, [data, search, openOnly]);
+  }, [data, search, openOnly, minSize, maxSize]);
 
   // Recommended tab — data from real API endpoint
   const recommended = recFilter === 'all'
@@ -494,7 +508,7 @@ export default function TeamBrowser() {
         {/* ── All teams ─────────────────────────────────────────────────────── */}
         {tab === 'all' && (
           <>
-            <Box sx={{ display: 'flex', gap: 1.25, mb: 3, alignItems: 'center', flexWrap: 'wrap' }}>
+            <Box sx={{ display: 'flex', gap: 1.25, mb: 1.5, alignItems: 'center', flexWrap: 'wrap' }}>
               <TextField
                 size="small"
                 placeholder="Search teams…"
@@ -523,6 +537,55 @@ export default function TeamBrowser() {
               <Typography variant="caption" fontFamily="monospace" color="text.disabled" sx={{ ml: 'auto' }}>
                 {filtered.length} team{filtered.length !== 1 ? 's' : ''}
               </Typography>
+            </Box>
+
+            {/* Second filter row */}
+            <Box sx={{ display: 'flex', gap: 1.25, mb: 3, alignItems: 'center', flexWrap: 'wrap' }}>
+              <FormControl size="small" sx={{ minWidth: 160 }}>
+                <InputLabel>Sort by</InputLabel>
+                <Select value={sortKey} label="Sort by" onChange={e => setSortKey(e.target.value)}>
+                  <MenuItem value=""><em>Default</em></MenuItem>
+                  <MenuItem value="name_asc">Name A–Z</MenuItem>
+                  <MenuItem value="name_desc">Name Z–A</MenuItem>
+                  <MenuItem value="spots_desc">Most spots first</MenuItem>
+                  <MenuItem value="spots_asc">Fewest spots first</MenuItem>
+                </Select>
+              </FormControl>
+
+              <TextField
+                size="small"
+                label="Min members"
+                type="number"
+                value={minSize}
+                onChange={e => setMinSize(e.target.value)}
+                slotProps={{ htmlInput: { min: 0, max: 20 } }}
+                sx={{ width: 120 }}
+              />
+              <TextField
+                size="small"
+                label="Max members"
+                type="number"
+                value={maxSize}
+                onChange={e => setMaxSize(e.target.value)}
+                slotProps={{ htmlInput: { min: 0, max: 20 } }}
+                sx={{ width: 120 }}
+              />
+
+              {(data?.questions ?? []).length > 0 && (
+                <FormControl size="small" sx={{ minWidth: 220, maxWidth: 320 }}>
+                  <InputLabel>Filter by shared answer</InputLabel>
+                  <Select
+                    value={filterQuestionId}
+                    label="Filter by shared answer"
+                    onChange={e => setFilterQuestionId(e.target.value)}
+                  >
+                    <MenuItem value=""><em>None</em></MenuItem>
+                    {(data.questions).map(q => (
+                      <MenuItem key={q.id} value={q.id}>{q.prompt}</MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              )}
             </Box>
 
             {filtered.length === 0 ? (


### PR DESCRIPTION
## Summary
- Implements `GET /search/teams` endpoint with name search, open spots filter, member count range, sort by name/spots, and a shared survey answer filter
- Wires the Team Browser to fetch teams from the backend instead of querying Supabase directly
- Adds sort and filter controls to the Team Browser UI
