### PR TITLE
Feat/profilepage

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -4,6 +4,7 @@ from routers.auth import router as auth_router
 from routers.recommendations import router as recommendations_router
 from routers.teams import router as teams_router
 from routers.surveys import router as surveys_router
+from routers.profiles import router as profiles_router
 
 app = FastAPI(
     title="Common Ground API",
@@ -26,6 +27,7 @@ app.include_router(auth_router)
 app.include_router(recommendations_router)
 app.include_router(teams_router)
 app.include_router(surveys_router)
+app.include_router(profiles_router)
 
 
 @app.get("/health", tags=["meta"])

--- a/backend/routers/profiles.py
+++ b/backend/routers/profiles.py
@@ -1,0 +1,123 @@
+from fastapi import APIRouter, Depends, HTTPException
+from auth import get_current_user, get_user_id
+from db import supabase
+from models.schemas import ProfileUpdate
+
+router = APIRouter(prefix="/profiles", tags=["profiles"])
+
+
+@router.get("/me")
+async def get_my_profile(user_id: str = Depends(get_user_id)):
+    """Return the current user's profile row."""
+    result = (
+        supabase.table("profiles")
+        .select("*")
+        .eq("id", user_id)
+        .single()
+        .execute()
+    )
+    if not result.data:
+        raise HTTPException(status_code=404, detail="Profile not found")
+    return result.data
+
+
+@router.patch("/me")
+async def update_my_profile(body: ProfileUpdate, user_id: str = Depends(get_user_id)):
+    """Update the current user's profile fields."""
+    updates = body.model_dump(exclude_none=True)
+    if not updates:
+        raise HTTPException(status_code=422, detail="No fields to update")
+
+    result = (
+        supabase.table("profiles")
+        .update(updates)
+        .eq("id", user_id)
+        .execute()
+    )
+    if not result.data:
+        raise HTTPException(status_code=500, detail="Failed to update profile")
+    return result.data[0]
+
+
+@router.get("/me/surveys")
+async def get_my_surveys(user_id: str = Depends(get_user_id)):
+    """
+    Return all surveys the current user is a member of,
+    along with their responses for each survey.
+    """
+    # Get all survey memberships for this user
+    members_res = (
+        supabase.table("survey_members")
+        .select("survey_id, joined_at, surveys(id, title)")
+        .eq("user_id", user_id)
+        .execute()
+    )
+
+    if not members_res.data:
+        return []
+
+    results = []
+    for membership in members_res.data:
+        survey = membership.get("surveys", {})
+        survey_id = membership["survey_id"]
+
+        # Get questions for this survey
+        questions_res = (
+            supabase.table("questions")
+            .select("id, prompt, question_type, order_index")
+            .eq("survey_id", survey_id)
+            .order("order_index")
+            .execute()
+        )
+
+        # Get this user's responses for this survey
+        responses_res = (
+            supabase.table("survey_responses")
+            .select("question_id, answer_option_id, answer_text")
+            .eq("survey_id", survey_id)
+            .eq("user_id", user_id)
+            .execute()
+        )
+
+        # Build answer map: question_id -> answer text/option
+        answer_map = {}
+        if responses_res.data:
+            # For multiple_choice we need to resolve the option text
+            option_ids = [
+                r["answer_option_id"]
+                for r in responses_res.data
+                if r.get("answer_option_id")
+            ]
+            option_text_map = {}
+            if option_ids:
+                opts_res = (
+                    supabase.table("answer_options")
+                    .select("id, option_text")
+                    .in_("id", option_ids)
+                    .execute()
+                )
+                if opts_res.data:
+                    option_text_map = {o["id"]: o["option_text"] for o in opts_res.data}
+
+            for r in responses_res.data:
+                if r.get("answer_option_id"):
+                    answer_map[r["question_id"]] = option_text_map.get(r["answer_option_id"], "")
+                else:
+                    answer_map[r["question_id"]] = r.get("answer_text", "")
+
+        # Build response list paired with question prompts
+        response_list = []
+        for q in (questions_res.data or []):
+            ans = answer_map.get(q["id"])
+            if ans is not None:
+                response_list.append({"q": q["prompt"], "a": ans})
+
+        results.append({
+            "survey_id": survey_id,
+            "title": survey.get("title", ""),
+            "joined_at": membership["joined_at"],
+            "submitted": len(response_list) > 0,
+            "responses": response_list,
+        })
+
+    return results

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
@@ -7,11 +7,13 @@ import Button from "@mui/material/Button";
 import TextField from "@mui/material/TextField";
 import MenuItem from "@mui/material/MenuItem";
 import Paper from "@mui/material/Paper";
-import Divider from "@mui/material/Divider";
 import Collapse from "@mui/material/Collapse";
 import Snackbar from "@mui/material/Snackbar";
 import Alert from "@mui/material/Alert";
-import Link from "@mui/material/Link";
+import CircularProgress from "@mui/material/CircularProgress";
+
+import { api } from "../api/client";
+import { useAuth } from "../context/AuthContext";
 
 // ── Static data ────────────────────────────────────────────────────────────────
 
@@ -23,31 +25,10 @@ const SCHOOLS = [
     "UMass Amherst",
 ];
 
-const SURVEY_PROFILES = [
-    {
-        id: "cs320",
-        name: "CS 320 Project Groups",
-        status: "Submitted",
-        responses: [
-            { q: "Working style",  a: "Plan ahead and divide work early" },
-            { q: "Availability",   a: "Weekday evenings" },
-            { q: "Background",     a: "Comfortable with Python and Java, learning React" },
-        ],
-    },
-    {
-        id: "math251",
-        name: "Math 251 Study Groups",
-        status: "Submitted",
-        responses: [
-            { q: "Preferred study style", a: "Group sessions with problem sets" },
-        ],
-    },
-];
-
 // ── Sub-components ─────────────────────────────────────────────────────────────
 
 function SurveyProfileCard({ profile }) {
-    const [open, setOpen] = useState(profile.id === "cs320");
+    const [open, setOpen] = useState(false);
 
     return (
         <Paper
@@ -69,20 +50,20 @@ function SurveyProfileCard({ profile }) {
                 }}
             >
                 <Typography variant="body2" fontWeight={500}>
-                    {profile.name}
+                    {profile.title}
                 </Typography>
                 <Typography
                     variant="caption"
                     sx={{
-                        bgcolor: "success.50",
-                        color: "success.main",
+                        bgcolor: profile.submitted ? "success.50" : "grey.200",
+                        color: profile.submitted ? "success.main" : "text.secondary",
                         px: 1,
                         py: 0.25,
                         borderRadius: 10,
                         fontFamily: "monospace",
                     }}
                 >
-                    {profile.status}
+                    {profile.submitted ? "Submitted" : "Joined"}
                 </Typography>
             </Box>
 
@@ -97,51 +78,124 @@ function SurveyProfileCard({ profile }) {
                         bgcolor: "background.paper",
                     }}
                 >
-                    {profile.responses.map((r) => (
-                        <Box
-                            key={r.q}
-                            sx={{ display: "flex", gap: 1, mb: 0.75 }}
-                        >
-                            <Typography
-                                variant="caption"
-                                color="text.disabled"
-                                sx={{ minWidth: 160 }}
+                    {profile.responses.length === 0 ? (
+                        <Typography variant="caption" color="text.disabled">
+                            No responses submitted yet.
+                        </Typography>
+                    ) : (
+                        profile.responses.map((r) => (
+                            <Box
+                                key={r.q}
+                                sx={{ display: "flex", gap: 1, mb: 0.75 }}
                             >
-                                {r.q}
-                            </Typography>
-                            <Typography variant="caption" fontWeight={500}>
-                                {r.a}
-                            </Typography>
-                        </Box>
-                    ))}
-                    <Link href="#" variant="caption" sx={{ display: "block", mt: 1.25 }}>
-                        Edit responses →
-                    </Link>
+                                <Typography
+                                    variant="caption"
+                                    color="text.disabled"
+                                    sx={{ minWidth: 160 }}
+                                >
+                                    {r.q}
+                                </Typography>
+                                <Typography variant="caption" fontWeight={500}>
+                                    {r.a}
+                                </Typography>
+                            </Box>
+                        ))
+                    )}
                 </Box>
             </Collapse>
         </Paper>
     );
 }
 
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function getInitials(name, email) {
+    if (name && name.trim()) {
+        const parts = name.trim().split(/\s+/);
+        return parts.length >= 2
+            ? (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
+            : parts[0].slice(0, 2).toUpperCase();
+    }
+    return email ? email[0].toUpperCase() : "?";
+}
+
 // ── Page ───────────────────────────────────────────────────────────────────────
 
 export default function Profile() {
+    const { user } = useAuth();
+
+    const [loading, setLoading]     = useState(true);
+    const [saving, setSaving]       = useState(false);
     const [savedOpen, setSavedOpen] = useState(false);
+    const [errorOpen, setErrorOpen] = useState(false);
+    const [errorMsg, setErrorMsg]   = useState("");
+    const [surveys, setSurveys]     = useState([]);
 
     // Form state
-    const [fullName,  setFullName]  = useState("Alice Chen");
-    const [email,     setEmail]     = useState("alice@amherst.edu");
-    const [school,    setSchool]    = useState("Amherst College");
-    const [major,     setMajor]     = useState("Computer Science");
-    const [gradYear,  setGradYear]  = useState("2026");
-    const [contact,   setContact]   = useState("alice#1234");
-    const [bio,       setBio]       = useState(
-        "Loves hackathons and hiking. Looking for teammates who are motivated and communicative."
-    );
+    const [fullName,  setFullName]  = useState("");
+    const [email,     setEmail]     = useState("");
+    const [school,    setSchool]    = useState("");
+    const [major,     setMajor]     = useState("");
+    const [gradYear,  setGradYear]  = useState("");
+    const [contact,   setContact]   = useState("");
+    const [bio,       setBio]       = useState("");
 
-    function handleSave() {
-        setSavedOpen(true);
+    // Load profile + surveys on mount
+    useEffect(() => {
+        async function load() {
+            try {
+                const [profile, surveyData] = await Promise.all([
+                    api.get("/profiles/me"),
+                    api.get("/profiles/me/surveys"),
+                ]);
+                setFullName(profile.full_name ?? "");
+                setEmail(profile.email ?? user?.email ?? "");
+                setSchool(profile.school ?? "");
+                setMajor(profile.major ?? "");
+                setGradYear(profile.grad_year != null ? String(profile.grad_year) : "");
+                setContact(profile.contact_info ?? "");
+                setBio(profile.bio ?? "");
+                setSurveys(surveyData);
+            } catch (err) {
+                setErrorMsg(err.message ?? "Failed to load profile");
+                setErrorOpen(true);
+            } finally {
+                setLoading(false);
+            }
+        }
+        load();
+    }, [user]);
+
+    async function handleSave() {
+        setSaving(true);
+        try {
+            const payload = {};
+            if (fullName)         payload.full_name    = fullName;
+            if (school)           payload.school       = school;
+            if (major)            payload.major        = major;
+            if (gradYear.trim())  payload.grad_year    = parseInt(gradYear, 10);
+            if (contact)          payload.contact_info = contact;
+            if (bio)              payload.bio          = bio;
+
+            await api.patch("/profiles/me", payload);
+            setSavedOpen(true);
+        } catch (err) {
+            setErrorMsg(err.message ?? "Failed to save");
+            setErrorOpen(true);
+        } finally {
+            setSaving(false);
+        }
     }
+
+    if (loading) {
+        return (
+            <Box sx={{ display: "flex", minHeight: "100vh", alignItems: "center", justifyContent: "center", bgcolor: "grey.100" }}>
+                <CircularProgress />
+            </Box>
+        );
+    }
+
+    const initials = getInitials(fullName, email);
 
     return (
         <Box sx={{ display: "flex", minHeight: "100vh", bgcolor: "grey.100" }}>
@@ -157,19 +211,14 @@ export default function Profile() {
                     sx={{ display: "flex", alignItems: "center", gap: 2.5, p: 3, mb: 2, borderRadius: 3 }}
                 >
                     <Avatar sx={{ width: 64, height: 64, fontSize: 22, fontWeight: 600, bgcolor: "primary.main" }}>
-                        AC
+                        {initials}
                     </Avatar>
                     <Box>
-                        <Typography fontWeight={600} fontSize={17}>Alice Chen</Typography>
-                        <Typography variant="caption" color="text.disabled" fontFamily="monospace">
-                            alice@amherst.edu
+                        <Typography fontWeight={600} fontSize={17}>
+                            {fullName || email}
                         </Typography>
-                        <Typography
-                            variant="caption"
-                            color="primary"
-                            sx={{ display: "block", mt: 0.75, cursor: "pointer" }}
-                        >
-                            Change photo
+                        <Typography variant="caption" color="text.disabled" fontFamily="monospace">
+                            {email}
                         </Typography>
                     </Box>
                 </Paper>
@@ -181,8 +230,15 @@ export default function Profile() {
                     </Typography>
 
                     <Box sx={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 2, mb: 2 }}>
-                        <TextField label="Full name"  size="small" value={fullName}  onChange={(e) => setFullName(e.target.value)} />
-                        <TextField label="Email"      size="small" value={email}     onChange={(e) => setEmail(e.target.value)} type="email" />
+                        <TextField label="Full name" size="small" value={fullName} onChange={(e) => setFullName(e.target.value)} />
+                        <TextField
+                            label="Email"
+                            size="small"
+                            value={email}
+                            type="email"
+                            InputProps={{ readOnly: true }}
+                            helperText="Email cannot be changed"
+                        />
                     </Box>
                     <Box sx={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 2, mb: 2 }}>
                         <TextField
@@ -192,6 +248,7 @@ export default function Profile() {
                             value={school}
                             onChange={(e) => setSchool(e.target.value)}
                         >
+                            <MenuItem value=""><em>Select school</em></MenuItem>
                             {SCHOOLS.map((s) => (
                                 <MenuItem key={s} value={s}>{s}</MenuItem>
                             ))}
@@ -199,7 +256,13 @@ export default function Profile() {
                         <TextField label="Major" size="small" value={major} onChange={(e) => setMajor(e.target.value)} />
                     </Box>
                     <Box sx={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 2, mb: 2 }}>
-                        <TextField label="Graduation year"  size="small" value={gradYear} onChange={(e) => setGradYear(e.target.value)} />
+                        <TextField
+                            label="Graduation year"
+                            size="small"
+                            value={gradYear}
+                            onChange={(e) => setGradYear(e.target.value)}
+                            inputProps={{ inputMode: "numeric" }}
+                        />
                         <TextField
                             label="Contact info"
                             size="small"
@@ -220,22 +283,21 @@ export default function Profile() {
                 </Paper>
 
                 {/* Survey profiles */}
-                <Paper variant="outlined" sx={{ p: 3, mb: 2, borderRadius: 3 }}>
-                    <Typography variant="caption" fontWeight={600} letterSpacing="0.02em" display="block" mb={2.25}>
-                        SURVEY PROFILES
-                    </Typography>
-                    {SURVEY_PROFILES.map((p) => (
-                        <SurveyProfileCard key={p.id} profile={p} />
-                    ))}
-                </Paper>
+                {surveys.length > 0 && (
+                    <Paper variant="outlined" sx={{ p: 3, mb: 2, borderRadius: 3 }}>
+                        <Typography variant="caption" fontWeight={600} letterSpacing="0.02em" display="block" mb={2.25}>
+                            SURVEY PROFILES
+                        </Typography>
+                        {surveys.map((s) => (
+                            <SurveyProfileCard key={s.survey_id} profile={s} />
+                        ))}
+                    </Paper>
+                )}
 
                 {/* Actions */}
                 <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1.25, mt: 1 }}>
-                    <Button variant="outlined" color="inherit" sx={{ color: "text.secondary" }}>
-                        Cancel
-                    </Button>
-                    <Button variant="contained" onClick={handleSave}>
-                        Save changes
+                    <Button variant="contained" onClick={handleSave} disabled={saving}>
+                        {saving ? "Saving…" : "Save changes"}
                     </Button>
                 </Box>
             </Box>
@@ -248,6 +310,17 @@ export default function Profile() {
             >
                 <Alert severity="success" onClose={() => setSavedOpen(false)}>
                     Changes saved
+                </Alert>
+            </Snackbar>
+
+            <Snackbar
+                open={errorOpen}
+                autoHideDuration={4000}
+                onClose={() => setErrorOpen(false)}
+                anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+            >
+                <Alert severity="error" onClose={() => setErrorOpen(false)}>
+                    {errorMsg}
                 </Alert>
             </Snackbar>
         </Box>


### PR DESCRIPTION
## Profile Page API

### Overview
Connected the Profile page to real database data so that profile edits are saved
permanently, the form is pre-populated on every visit, and newly registered users
see their email already filled in with all other fields blank and ready to complete.

---

### API endpoints — `backend/routers/profiles.py`

**`GET /profiles/me`**
- Returns the current user's full profile row from the `profiles` table
- Called on page load to pre-populate every field
- Returns 404 if the row does not exist yet

**`PATCH /profiles/me`**
- Accepts a partial body (`full_name`, `school`, `major`, `grad_year`, `bio`, `contact_info`)
- Only sends fields that are non-empty, so a partial save never overwrites existing data with blanks
- Returns the updated profile row on success

**`GET /profiles/me/surveys`**
- Returns every survey the user has joined, along with their submitted responses
- For each survey: resolves `answer_option_id` → human-readable `option_text` by joining `answer_options`
- Used to populate the "Survey Profiles" section at the bottom of the page

All three endpoints are authenticated via the `get_user_id` dependency (extracts the user ID from the Supabase JWT), so no user ID needs to be passed in the URL.

The router was registered in `main.py` under the `/profiles` prefix.

---
### Frontend changes — `frontend/src/pages/Profile.jsx`

- All form fields (`full_name`, `school`, `major`, `grad_year`, `bio`, `contact_info`) are fetched from the database on mount and pre-populated, so returning to the page always shows the latest saved values
- New users see only their email pre-populated (set by Supabase during registration); all other fields start blank
- Email field is read-only since it is owned by Supabase Auth and cannot be changed from the app
- Clicking **Save Profile** calls `PATCH /profiles/me` with only non-empty fields, persisting changes to the database
- Avatar initials are computed dynamically from `full_name`, falling back to the first letter of the email
- A `CircularProgress` spinner is shown while the initial data fetch is in-flight
- A Snackbar toast confirms a successful save or displays an error message if the request fails
- The "Survey Profiles" section is hidden for new users and only appears once the user has joined at least one survey; responses are read-only
- On every page load, the latest saved values are fetched from the database and written into form state, so navigating away and returning never loses data.
- New users get only their email pre-populated (set by Supabase during registration); all other fields start blank and are saved the first time the user clicks **Save Profile**.