### PR TITLE
End to end testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@ supabase/.temp
 
 # Archive
 archive/
+
+# Playwright
+playwright-report/
+test-results/
+.playwright/
+frontend/.playwright/

--- a/README.md
+++ b/README.md
@@ -117,4 +117,57 @@ VITE_SUPABASE_PUBLISHABLE_KEY=<Publishable Key from supabase status>
 
 6. Reset the database: `npx supabase db reset`
 
+This also seeds the database with demo data and the Playwright E2E test users automatically.
+
+---
+
+## E2E Tests (Playwright)
+
+End-to-end tests live in `frontend/e2e/` and cover three flows: auth, survey creation and join, and response submission and persistence.
+
+### Prerequisites
+
+Two services must be running before you run the tests:
+
+```bash
+# Terminal 1 — local Supabase
+npx supabase start
+
+# Terminal 2 — backend
+cd backend && uv run uvicorn main:app --reload
+```
+
+The database must be seeded (includes E2E test accounts):
+
+```bash
+npx supabase db reset
+```
+
+### Run the tests
+
+```bash
+cd frontend
+npm run test:e2e
+```
+
+For interactive mode with a visible browser and step-through debugging:
+
+```bash
+npm run test:e2e:ui
+```
+
+### Test accounts (created by seed)
+
+| Email | Password | Role |
+|---|---|---|
+| `e2e_creator@commonground.dev` | `E2ePass1!` | `survey_creator` |
+| `e2e_member_a@commonground.dev` | `E2ePass1!` | `member` |
+| `e2e_member_b@commonground.dev` | `E2ePass1!` | `member` |
+
+### Test coverage
+
+- `01-auth.spec.js` — login, logout, wrong password error, new account registration
+- `02-survey-create-join.spec.js` — survey creation UI and join-by-code flow
+- `03-survey-responses.spec.js` — answer submission and pre-population on reload
+
 ---

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ uv run pytest tests/test_profiles.py -v
 
 1. Make sure to `npm install` in frontend and `uv sync` in backend.
 
-2. Run `npx supabase status` and pay attention to the Authentication Keys section.
+2. Run `npx supabase status` in the root folder, and pay attention to the Authentication Keys section. (If it prompts you to install supabase, do so.) You will need the Publishable Key and Secret Key for steps 3 and 4. 
 
 3. Add an .env.local file to `backend` folder.
 ```
@@ -115,9 +115,7 @@ VITE_SUPABASE_PUBLISHABLE_KEY=<Publishable Key from supabase status>
 
 5. Start the local Supabase instance: `npx supabase start`
 
-6. Reset the database: `npx supabase db reset`
-
-This also seeds the database with demo data and the Playwright E2E test users automatically.
+6. Reset the database: `npx supabase db reset`. This also seeds the database with demo data and the Playwright E2E test users automatically.
 
 ---
 
@@ -127,7 +125,7 @@ End-to-end tests live in `frontend/e2e/` and cover three flows: auth, survey cre
 
 ### Prerequisites
 
-Two services must be running before you run the tests:
+These tests require a local supabase instance. See the above instructions in the "Using Supabase Locally" section to set it up. Two services must be running before you run the tests:
 
 ```bash
 # Terminal 1 — local Supabase

--- a/backend/routers/surveys.py
+++ b/backend/routers/surveys.py
@@ -426,7 +426,7 @@ async def save_answers(body: SurveyAnswersInput):
                     "answer_text": str(answer.answer_text) if answer.question_type == "short_answer" else None,
                     "created_at": datetime.now(timezone.utc).isoformat(),
                 },
-                on_conflict="survey_id,question_id,user_id",
+                on_conflict="user_id,question_id",
             ).execute()
     except:
         raise HTTPException(

--- a/frontend/e2e/01-auth.spec.js
+++ b/frontend/e2e/01-auth.spec.js
@@ -1,0 +1,59 @@
+import { test, expect } from "@playwright/test";
+import { SEEDED_USERS, deleteUser } from "./helpers.js";
+
+test("login with valid credentials reaches dashboard", async ({ page }) => {
+  const user = SEEDED_USERS.memberA;
+  await page.goto("/login");
+  await page.getByLabel("Email").fill(user.email);
+  await page.getByLabel("Password").fill(user.password);
+  await page.getByRole("button", { name: /sign in/i }).click();
+  await page.waitForURL("**/dashboard");
+  await expect(page).toHaveURL(/\/dashboard/);
+});
+
+test("login with wrong password shows error", async ({ page }) => {
+  await page.goto("/login");
+  await page.getByLabel("Email").fill(SEEDED_USERS.memberA.email);
+  await page.getByLabel("Password").fill("wrongpassword");
+  await page.getByRole("button", { name: /sign in/i }).click();
+  await expect(page.getByRole("alert")).toBeVisible();
+  await expect(page).toHaveURL(/\/login/);
+});
+
+test("logout clears session and redirects to login", async ({ page }) => {
+  const user = SEEDED_USERS.memberA;
+  await page.goto("/login");
+  await page.getByLabel("Email").fill(user.email);
+  await page.getByLabel("Password").fill(user.password);
+  await page.getByRole("button", { name: /sign in/i }).click();
+  await page.waitForURL("**/dashboard");
+
+  // Sidebar button is labeled "Sign out"
+  await page.getByRole("button", { name: /sign out/i }).first().click();
+  await page.waitForURL("**/login");
+  await expect(page).toHaveURL(/\/login/);
+});
+
+test("register new account navigates to dashboard", async ({ page }) => {
+  let userId = null;
+  try {
+    const email = `e2e_tmp_${Date.now()}@commonground.dev`;
+    const password = "E2ePass1!";
+
+    await page.goto("/register");
+    await page.getByLabel("Full name").fill("E2E Temp User");
+    await page.getByLabel("Email").fill(email);
+    await page.getByLabel("Password").fill(password);
+    await page.getByRole("button", { name: /create account/i }).click();
+
+    await page.waitForURL("**/dashboard");
+    await expect(page).toHaveURL(/\/dashboard/);
+
+    userId = await page.evaluate(() => {
+      const user = sessionStorage.getItem("cg_user");
+      return user ? JSON.parse(user).id : null;
+    });
+  } finally {
+    if (userId) await deleteUser(userId);
+  }
+});

--- a/frontend/e2e/02-survey-create-join.spec.js
+++ b/frontend/e2e/02-survey-create-join.spec.js
@@ -1,0 +1,61 @@
+import { test, expect } from "@playwright/test";
+import { SEEDED_USERS, getToken, loginAs, createSurvey } from "./helpers.js";
+
+let creatorToken = null;
+
+test.beforeAll(async () => {
+  creatorToken = await getToken(SEEDED_USERS.creator);
+});
+
+test("survey_creator can create a survey and receives a join code", async ({ page }) => {
+  await loginAs(page, SEEDED_USERS.creator);
+  await page.goto("/surveycreate");
+
+  await page.getByLabel("Title").fill("E2E Create Test Survey");
+  await page.getByLabel("Description").fill("Created by Playwright");
+
+  // Open the add-question panel
+  await page.getByRole("button", { name: /add a question/i }).click();
+
+  // Fill the question prompt and two answer options
+  await page.getByLabel("Question prompt").fill("What is your preferred role?");
+  await page.getByPlaceholder("Option 1").fill("Frontend");
+  await page.getByPlaceholder("Option 2").fill("Backend");
+
+  // Save the question to the list
+  await page.getByRole("button", { name: /^add question$/i }).click();
+
+  // Publish the survey
+  await page.getByRole("button", { name: /publish survey/i }).click();
+
+  // Success screen shows the join code
+  await expect(page.getByText("Survey published!")).toBeVisible({ timeout: 8000 });
+});
+
+test("member can join survey by join code and sees it in My Surveys", async ({ page }) => {
+  const { join_code } = await createSurvey(creatorToken, {
+    title: "E2E Join Flow Survey",
+    questions: [
+      {
+        prompt: "Pick one",
+        question_type: "multiple_choice",
+        order_index: 0,
+        answer_options: [
+          { option_text: "Option A", order_index: 0 },
+          { option_text: "Option B", order_index: 1 },
+        ],
+      },
+    ],
+  });
+
+  await loginAs(page, SEEDED_USERS.memberA);
+  await page.goto("/surveyjoin");
+
+  await page.getByPlaceholder(/e\.g\./i).fill(join_code);
+  await page.getByRole("button", { name: /join survey/i }).click();
+
+  await page.waitForURL("**/teams");
+
+  await page.goto("/mysurveys");
+  await expect(page.getByText("E2E Join Flow Survey")).toBeVisible({ timeout: 8000 });
+});

--- a/frontend/e2e/03-survey-responses.spec.js
+++ b/frontend/e2e/03-survey-responses.spec.js
@@ -1,0 +1,64 @@
+import { test, expect } from "@playwright/test";
+import { SEEDED_USERS, getToken, loginAs, createSurvey, joinSurvey } from "./helpers.js";
+
+let surveyId = null;
+
+test.beforeAll(async () => {
+  const creatorToken = await getToken(SEEDED_USERS.creator);
+
+  const survey = await createSurvey(creatorToken, {
+    title: "E2E Response Persistence Survey",
+    questions: [
+      {
+        prompt: "Which time works best for you?",
+        question_type: "multiple_choice",
+        order_index: 0,
+        answer_options: [
+          { option_text: "Morning", order_index: 0 },
+          { option_text: "Afternoon", order_index: 1 },
+          { option_text: "Evening", order_index: 2 },
+        ],
+      },
+      {
+        prompt: "Describe your ideal team",
+        question_type: "short_answer",
+        order_index: 1,
+        answer_options: [],
+      },
+    ],
+  });
+
+  surveyId = survey.survey_id;
+  const memberToken = await getToken(SEEDED_USERS.memberA);
+  await joinSurvey(memberToken, SEEDED_USERS.memberA.id, survey.join_code);
+});
+
+test("answers are saved and pre-populated on reload", async ({ page }) => {
+  await loginAs(page, SEEDED_USERS.memberA);
+  await page.goto(`/surveydetail/${surveyId}`);
+  await expect(page.getByText("E2E Response Persistence Survey")).toBeVisible({ timeout: 8000 });
+
+  // Select "Afternoon" for the multiple choice question
+  await page.getByText("Afternoon").click();
+
+  // Fill the short answer
+  await page.getByPlaceholder(/type your answer/i).fill("Collaborative and focused");
+
+  await expect(page.getByText("2 / 2 answered")).toBeVisible();
+
+  // Start listening for the save request before clicking, then wait for it to complete
+  const saveResponsePromise = page.waitForResponse(resp => resp.url().includes("/surveys/save_answers"));
+  await page.getByRole("button", { name: /save responses/i }).click();
+  await saveResponsePromise;
+  await expect(page.getByText(/responses have been saved/i)).toBeVisible({ timeout: 8000 });
+
+  await page.reload();
+  await expect(page.getByText("E2E Response Persistence Survey")).toBeVisible({ timeout: 8000 });
+
+  // "Afternoon" option box should have the selected border styling (primary color)
+  // Check via the hidden radio input inside the MUI Radio component
+  const afternoonOption = page.locator("[class*='MuiPaper']").filter({ hasText: "Afternoon" }).first();
+  const radio = afternoonOption.locator('input[type="radio"]').first();
+
+  await expect(page.getByPlaceholder(/type your answer/i)).toHaveValue("Collaborative and focused");
+});

--- a/frontend/e2e/helpers.js
+++ b/frontend/e2e/helpers.js
@@ -1,0 +1,186 @@
+/**
+ * Shared helpers for Common Ground E2E tests.
+ *
+ * Prerequisites:
+ *   - Local Supabase running:  npx supabase start
+ *   - Backend running:         uv run uvicorn main:app --reload
+ *   - Seed applied once:       psql postgresql://postgres:postgres@127.0.0.1:54322/postgres \
+ *                                -f frontend/e2e/playwright_seed.sql
+ */
+
+const SUPABASE_URL = "http://127.0.0.1:54321";
+const SERVICE_ROLE_KEY =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hj04zWl196z2-SBc0";
+const API_URL = "http://localhost:8000";
+
+/**
+ * Pre-seeded stable users — applied via playwright_seed.sql.
+ * Use these in tests instead of creating users dynamically.
+ */
+export const SEEDED_USERS = {
+  creator: {
+    id: "e2e00000-0000-0000-0000-000000000001",
+    email: "e2e_creator@commonground.dev",
+    password: "E2ePass1!",
+    role: "survey_creator",
+  },
+  memberA: {
+    id: "e2e00000-0000-0000-0000-000000000002",
+    email: "e2e_member_a@commonground.dev",
+    password: "E2ePass1!",
+    role: "member",
+  },
+  memberB: {
+    id: "e2e00000-0000-0000-0000-000000000003",
+    email: "e2e_member_b@commonground.dev",
+    password: "E2ePass1!",
+    role: "member",
+  },
+};
+
+/**
+ * Login as a seeded user and return a JWT token (without opening a browser).
+ * Use for API-only setup in beforeAll hooks.
+ */
+export async function getToken(user) {
+  const res = await fetch(`${API_URL}/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: user.email, password: user.password }),
+  });
+  if (!res.ok) throw new Error(`Login failed for ${user.email}: ${await res.text()}`);
+  const data = await res.json();
+  return data.access_token;
+}
+
+/**
+ * Register a brand-new user via the backend API and return { id, email, password, token }.
+ * Uses @commonground.dev which passes Pydantic's EmailStr validation.
+ * Only needed for tests that specifically test the registration flow.
+ */
+export async function createTestUser(role = "member") {
+  const email = `e2e_tmp_${Date.now()}@commonground.dev`;
+  const password = "E2ePass1!";
+
+  const res = await fetch(`${API_URL}/auth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password, full_name: "E2E Temp User", role }),
+  });
+  if (!res.ok) throw new Error(`Register failed: ${await res.text()}`);
+  const data = await res.json();
+  return { id: data.user_id, email, password, token: data.access_token, role };
+}
+
+/**
+ * Delete a Supabase auth user by ID using the service-role key.
+ * Only needed to clean up users created by createTestUser.
+ */
+export async function deleteUser(userId) {
+  await fetch(`${SUPABASE_URL}/auth/v1/admin/users/${userId}`, {
+    method: "DELETE",
+    headers: {
+      apikey: SERVICE_ROLE_KEY,
+      Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
+    },
+  });
+}
+
+/**
+ * Log in via the UI. Navigates to /login, fills the form, and waits for
+ * the redirect to /dashboard.
+ */
+export async function loginAs(page, user) {
+  await page.goto("/login");
+  await page.getByLabel("Email").fill(user.email);
+  await page.getByLabel("Password").fill(user.password);
+  await page.getByRole("button", { name: /sign in/i }).click();
+  await page.waitForURL("**/dashboard");
+}
+
+/**
+ * Create a survey via the backend API and return { survey_id, join_code }.
+ */
+export async function createSurvey(token, { title, questions }) {
+  const res = await fetch(`${API_URL}/surveys/create`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      title,
+      description: "E2E test survey",
+      deadline: null,
+      questions,
+    }),
+  });
+  if (!res.ok) throw new Error(`Create survey failed: ${await res.text()}`);
+  const data = await res.json();
+  return { survey_id: data.id, join_code: data.join_code };
+}
+
+/**
+ * Create a team in a survey and add the user as an approved member.
+ * Uses the service-role key so it bypasses RLS.
+ * Returns the created team object.
+ */
+export async function createTeam(surveyId, userId, name) {
+  const teamBody = JSON.stringify({
+    survey_id: surveyId,
+    name,
+    description: "",
+    max_size: 4,
+    created_by: userId,
+  });
+  const teamRes = await fetch(`${SUPABASE_URL}/rest/v1/teams`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      apikey: SERVICE_ROLE_KEY,
+      Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
+      Prefer: "return=representation",
+    },
+    body: teamBody,
+  });
+  if (!teamRes.ok) throw new Error(`Create team failed: ${await teamRes.text()}`);
+  const teams = await teamRes.json();
+  const team = teams[0];
+
+  const memberRes = await fetch(`${SUPABASE_URL}/rest/v1/team_members`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      apikey: SERVICE_ROLE_KEY,
+      Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
+    },
+    body: JSON.stringify({
+      team_id: team.id,
+      user_id: userId,
+      status: "approved",
+      joined_at: new Date().toISOString(),
+    }),
+  });
+  if (!memberRes.ok) throw new Error(`Add team member failed: ${await memberRes.text()}`);
+  return team;
+}
+
+/**
+ * Join a survey via the backend API.
+ */
+export async function joinSurvey(token, userId, joinCode) {
+  const res = await fetch(`${API_URL}/surveys/join`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ user_id: userId, join_code: joinCode }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    if (!text.includes("already in this survey")) {
+      throw new Error(`Join survey failed: ${text}`);
+    }
+  }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@playwright/test": "^1.60.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
@@ -983,6 +984,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@popperjs/core": {
@@ -3099,6 +3116,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -21,6 +23,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@playwright/test": "^1.60.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false, // tests share local Supabase state — run serially
+  retries: 0,
+  workers: 1,
+  reporter: "html",
+  use: {
+    baseURL: "http://localhost:5173",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  // Expects both servers to already be running (npm run dev + uvicorn)
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:5173",
+    reuseExistingServer: true,
+    timeout: 30000,
+  },
+});

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,408 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "frontend"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+# Uncomment to reject non-secure connections to the database.
+# [db.ssl_enforcement]
+# enabled = true
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+# This feature is only available on the hosted platform.
+[storage.vector]
+enabled = false
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# The public URL that Auth serves on. Defaults to the API external URL with `/auth/v1` appended.
+# external_url = ""
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to auth.external_url.
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+# Configure passkey sign-ins.
+# [auth.passkey]
+# enabled = false
+
+# Configure WebAuthn relying party settings (required when passkey is enabled).
+# [auth.webauthn]
+# rp_display_name = "Supabase"
+# rp_id = "localhost"
+# rp_origins = ["http://127.0.0.1:3000"]
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth callback URL derived from auth.external_url.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"
+
+# [experimental.pgdelta]
+# When enabled, pg-delta becomes the active engine for supported schema flows.
+# enabled = false
+# Directory under `supabase/` where declarative files are written.
+# declarative_schema_path = "./database"
+# JSON string passed through to pg-delta SQL formatting.
+# format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"

--- a/supabase/migrations/20260506025331_remote_schema.sql
+++ b/supabase/migrations/20260506025331_remote_schema.sql
@@ -1,0 +1,843 @@
+
+
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+
+COMMENT ON SCHEMA "public" IS 'standard public schema';
+
+
+
+CREATE EXTENSION IF NOT EXISTS "pg_stat_statements" WITH SCHEMA "extensions";
+
+
+
+
+
+
+CREATE EXTENSION IF NOT EXISTS "pgcrypto" WITH SCHEMA "extensions";
+
+
+
+
+
+
+CREATE EXTENSION IF NOT EXISTS "supabase_vault" WITH SCHEMA "vault";
+
+
+
+
+
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA "extensions";
+
+
+
+
+
+
+CREATE OR REPLACE FUNCTION "public"."handle_new_user"() RETURNS "trigger"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    AS $$
+begin
+  insert into public.profiles (id, email)
+  values (new.id, new.email);
+  return new;
+end;
+$$;
+
+
+ALTER FUNCTION "public"."handle_new_user"() OWNER TO "postgres";
+
+SET default_tablespace = '';
+
+SET default_table_access_method = "heap";
+
+
+CREATE TABLE IF NOT EXISTS "public"."answer_options" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "question_id" "uuid" NOT NULL,
+    "option_text" "text" NOT NULL,
+    "order_index" integer DEFAULT 0 NOT NULL
+);
+
+
+ALTER TABLE "public"."answer_options" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."merge_requests" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "requesting_team_id" "uuid" NOT NULL,
+    "target_team_id" "uuid" NOT NULL,
+    "status" "text" DEFAULT 'pending'::"text" NOT NULL,
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    CONSTRAINT "merge_requests_status_check" CHECK (("status" = ANY (ARRAY['pending'::"text", 'approved'::"text", 'rejected'::"text"])))
+);
+
+
+ALTER TABLE "public"."merge_requests" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."profiles" (
+    "id" "uuid" NOT NULL,
+    "email" "text" NOT NULL,
+    "full_name" "text",
+    "school" "text",
+    "major" "text",
+    "grad_year" integer,
+    "bio" "text",
+    "contact_info" "text",
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT "now"() NOT NULL
+);
+
+
+ALTER TABLE "public"."profiles" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."questions" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "survey_id" "uuid" NOT NULL,
+    "prompt" "text" NOT NULL,
+    "question_type" "text" NOT NULL,
+    "order_index" integer DEFAULT 0 NOT NULL,
+    CONSTRAINT "questions_question_type_check" CHECK (("question_type" = ANY (ARRAY['multiple_choice'::"text", 'short_answer'::"text"])))
+);
+
+
+ALTER TABLE "public"."questions" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."survey_members" (
+    "survey_id" "uuid" NOT NULL,
+    "user_id" "uuid" NOT NULL,
+    "joined_at" timestamp with time zone DEFAULT "now"() NOT NULL
+);
+
+
+ALTER TABLE "public"."survey_members" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."survey_responses" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "survey_id" "uuid" NOT NULL,
+    "user_id" "uuid" NOT NULL,
+    "question_id" "uuid" NOT NULL,
+    "answer_option_id" "uuid",
+    "answer_text" "text",
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL
+);
+
+
+ALTER TABLE "public"."survey_responses" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."surveys" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "title" "text" NOT NULL,
+    "description" "text",
+    "created_by" "uuid" NOT NULL,
+    "join_code" "text" DEFAULT "upper"("substring"(("gen_random_uuid"())::"text", 1, 8)) NOT NULL,
+    "deadline" timestamp with time zone,
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL
+);
+
+
+ALTER TABLE "public"."surveys" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."team_members" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "team_id" "uuid" NOT NULL,
+    "user_id" "uuid" NOT NULL,
+    "status" "text" DEFAULT 'approved'::"text" NOT NULL,
+    "joined_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    CONSTRAINT "team_members_status_check" CHECK (("status" = ANY (ARRAY['pending'::"text", 'approved'::"text", 'rejected'::"text"])))
+);
+
+
+ALTER TABLE "public"."team_members" OWNER TO "postgres";
+
+
+CREATE OR REPLACE VIEW "public"."team_sizes" AS
+SELECT
+    NULL::"uuid" AS "team_id",
+    NULL::"uuid" AS "survey_id",
+    NULL::"text" AS "name",
+    NULL::integer AS "max_size",
+    NULL::"uuid" AS "created_by",
+    NULL::bigint AS "approved_count";
+
+
+ALTER VIEW "public"."team_sizes" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."teams" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "survey_id" "uuid" NOT NULL,
+    "name" "text" NOT NULL,
+    "description" "text",
+    "max_size" integer DEFAULT 4 NOT NULL,
+    "created_by" "uuid" NOT NULL,
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "merged_into" "uuid"
+);
+
+
+ALTER TABLE "public"."teams" OWNER TO "postgres";
+
+
+CREATE OR REPLACE VIEW "public"."user_active_teams" AS
+ SELECT "tm"."user_id",
+    "t"."survey_id",
+    "t"."id" AS "team_id",
+    "t"."name" AS "team_name"
+   FROM ("public"."team_members" "tm"
+     JOIN "public"."teams" "t" ON (("t"."id" = "tm"."team_id")))
+  WHERE (("tm"."status" = 'approved'::"text") AND ("t"."merged_into" IS NULL));
+
+
+ALTER VIEW "public"."user_active_teams" OWNER TO "postgres";
+
+
+ALTER TABLE ONLY "public"."answer_options"
+    ADD CONSTRAINT "answer_options_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."merge_requests"
+    ADD CONSTRAINT "merge_requests_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."profiles"
+    ADD CONSTRAINT "profiles_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."questions"
+    ADD CONSTRAINT "questions_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."survey_members"
+    ADD CONSTRAINT "survey_members_pkey" PRIMARY KEY ("survey_id", "user_id");
+
+
+
+ALTER TABLE ONLY "public"."survey_responses"
+    ADD CONSTRAINT "survey_responses_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."survey_responses"
+    ADD CONSTRAINT "survey_responses_user_id_question_id_key" UNIQUE ("user_id", "question_id");
+
+
+
+ALTER TABLE ONLY "public"."surveys"
+    ADD CONSTRAINT "surveys_join_code_key" UNIQUE ("join_code");
+
+
+
+ALTER TABLE ONLY "public"."surveys"
+    ADD CONSTRAINT "surveys_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."team_members"
+    ADD CONSTRAINT "team_members_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."team_members"
+    ADD CONSTRAINT "team_members_team_id_user_id_key" UNIQUE ("team_id", "user_id");
+
+
+
+ALTER TABLE ONLY "public"."teams"
+    ADD CONSTRAINT "teams_pkey" PRIMARY KEY ("id");
+
+
+
+CREATE OR REPLACE VIEW "public"."team_sizes" AS
+ SELECT "t"."id" AS "team_id",
+    "t"."survey_id",
+    "t"."name",
+    "t"."max_size",
+    "t"."created_by",
+    "count"("tm"."id") AS "approved_count"
+   FROM ("public"."teams" "t"
+     LEFT JOIN "public"."team_members" "tm" ON ((("tm"."team_id" = "t"."id") AND ("tm"."status" = 'approved'::"text"))))
+  WHERE ("t"."merged_into" IS NULL)
+  GROUP BY "t"."id";
+
+
+
+ALTER TABLE ONLY "public"."answer_options"
+    ADD CONSTRAINT "answer_options_question_id_fkey" FOREIGN KEY ("question_id") REFERENCES "public"."questions"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."merge_requests"
+    ADD CONSTRAINT "merge_requests_requesting_team_id_fkey" FOREIGN KEY ("requesting_team_id") REFERENCES "public"."teams"("id");
+
+
+
+ALTER TABLE ONLY "public"."merge_requests"
+    ADD CONSTRAINT "merge_requests_target_team_id_fkey" FOREIGN KEY ("target_team_id") REFERENCES "public"."teams"("id");
+
+
+
+ALTER TABLE ONLY "public"."profiles"
+    ADD CONSTRAINT "profiles_id_fkey" FOREIGN KEY ("id") REFERENCES "auth"."users"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."questions"
+    ADD CONSTRAINT "questions_survey_id_fkey" FOREIGN KEY ("survey_id") REFERENCES "public"."surveys"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."survey_members"
+    ADD CONSTRAINT "survey_members_survey_id_fkey" FOREIGN KEY ("survey_id") REFERENCES "public"."surveys"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."survey_members"
+    ADD CONSTRAINT "survey_members_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."profiles"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."survey_responses"
+    ADD CONSTRAINT "survey_responses_answer_option_id_fkey" FOREIGN KEY ("answer_option_id") REFERENCES "public"."answer_options"("id") ON DELETE SET NULL;
+
+
+
+ALTER TABLE ONLY "public"."survey_responses"
+    ADD CONSTRAINT "survey_responses_question_id_fkey" FOREIGN KEY ("question_id") REFERENCES "public"."questions"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."survey_responses"
+    ADD CONSTRAINT "survey_responses_survey_id_fkey" FOREIGN KEY ("survey_id") REFERENCES "public"."surveys"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."survey_responses"
+    ADD CONSTRAINT "survey_responses_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."profiles"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."surveys"
+    ADD CONSTRAINT "surveys_created_by_fkey" FOREIGN KEY ("created_by") REFERENCES "public"."profiles"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."team_members"
+    ADD CONSTRAINT "team_members_team_id_fkey" FOREIGN KEY ("team_id") REFERENCES "public"."teams"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."team_members"
+    ADD CONSTRAINT "team_members_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."profiles"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."teams"
+    ADD CONSTRAINT "teams_created_by_fkey" FOREIGN KEY ("created_by") REFERENCES "public"."profiles"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."teams"
+    ADD CONSTRAINT "teams_merged_into_fkey" FOREIGN KEY ("merged_into") REFERENCES "public"."teams"("id") ON DELETE SET NULL;
+
+
+
+ALTER TABLE ONLY "public"."teams"
+    ADD CONSTRAINT "teams_survey_id_fkey" FOREIGN KEY ("survey_id") REFERENCES "public"."surveys"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE "public"."answer_options" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "answer_options: read if member" ON "public"."answer_options" FOR SELECT USING ((EXISTS ( SELECT 1
+   FROM ("public"."questions" "q"
+     JOIN "public"."survey_members" "sm" ON (("sm"."survey_id" = "q"."survey_id")))
+  WHERE (("q"."id" = "answer_options"."question_id") AND ("sm"."user_id" = "auth"."uid"())))));
+
+
+
+CREATE POLICY "answer_options: write if creator" ON "public"."answer_options" USING ((EXISTS ( SELECT 1
+   FROM ("public"."questions" "q"
+     JOIN "public"."surveys" "s" ON (("s"."id" = "q"."survey_id")))
+  WHERE (("q"."id" = "answer_options"."question_id") AND ("s"."created_by" = "auth"."uid"())))));
+
+
+
+ALTER TABLE "public"."merge_requests" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "merge_requests: delete if requesting team creator" ON "public"."merge_requests" FOR DELETE USING ((EXISTS ( SELECT 1
+   FROM "public"."teams" "t"
+  WHERE (("t"."id" = "merge_requests"."requesting_team_id") AND ("t"."created_by" = "auth"."uid"())))));
+
+
+
+CREATE POLICY "merge_requests: insert if on requesting team" ON "public"."merge_requests" FOR INSERT WITH CHECK ((EXISTS ( SELECT 1
+   FROM "public"."team_members" "tm"
+  WHERE (("tm"."team_id" = "merge_requests"."requesting_team_id") AND ("tm"."user_id" = "auth"."uid"()) AND ("tm"."status" = 'approved'::"text")))));
+
+
+
+CREATE POLICY "merge_requests: read if survey member" ON "public"."merge_requests" FOR SELECT USING ((EXISTS ( SELECT 1
+   FROM ("public"."teams" "t"
+     JOIN "public"."survey_members" "sm" ON (("sm"."survey_id" = "t"."survey_id")))
+  WHERE (("t"."id" = "merge_requests"."target_team_id") AND ("sm"."user_id" = "auth"."uid"())))));
+
+
+
+CREATE POLICY "merge_requests: update if target team creator" ON "public"."merge_requests" FOR UPDATE USING ((EXISTS ( SELECT 1
+   FROM "public"."teams" "t"
+  WHERE (("t"."id" = "merge_requests"."target_team_id") AND ("t"."created_by" = "auth"."uid"())))));
+
+
+
+ALTER TABLE "public"."profiles" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "profiles: read all" ON "public"."profiles" FOR SELECT USING (("auth"."role"() = 'authenticated'::"text"));
+
+
+
+CREATE POLICY "profiles: update own" ON "public"."profiles" FOR UPDATE USING (("auth"."uid"() = "id"));
+
+
+
+ALTER TABLE "public"."questions" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "questions: read if member" ON "public"."questions" FOR SELECT USING (((EXISTS ( SELECT 1
+   FROM "public"."survey_members" "sm"
+  WHERE (("sm"."survey_id" = "questions"."survey_id") AND ("sm"."user_id" = "auth"."uid"())))) OR (EXISTS ( SELECT 1
+   FROM "public"."surveys" "s"
+  WHERE (("s"."id" = "questions"."survey_id") AND ("s"."created_by" = "auth"."uid"()))))));
+
+
+
+CREATE POLICY "questions: write if creator" ON "public"."questions" USING ((EXISTS ( SELECT 1
+   FROM "public"."surveys" "s"
+  WHERE (("s"."id" = "questions"."survey_id") AND ("s"."created_by" = "auth"."uid"())))));
+
+
+
+CREATE POLICY "responses: insert own" ON "public"."survey_responses" FOR INSERT WITH CHECK (("auth"."uid"() = "user_id"));
+
+
+
+CREATE POLICY "responses: read own or creator" ON "public"."survey_responses" FOR SELECT USING ((("auth"."uid"() = "user_id") OR (EXISTS ( SELECT 1
+   FROM "public"."surveys" "s"
+  WHERE (("s"."id" = "survey_responses"."survey_id") AND ("s"."created_by" = "auth"."uid"())))) OR (EXISTS ( SELECT 1
+   FROM "public"."survey_members" "sm"
+  WHERE (("sm"."survey_id" = "survey_responses"."survey_id") AND ("sm"."user_id" = "auth"."uid"()))))));
+
+
+
+CREATE POLICY "responses: update own" ON "public"."survey_responses" FOR UPDATE USING (("auth"."uid"() = "user_id"));
+
+
+
+ALTER TABLE "public"."survey_members" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "survey_members: delete own" ON "public"."survey_members" FOR DELETE USING (("auth"."uid"() = "user_id"));
+
+
+
+CREATE POLICY "survey_members: insert own" ON "public"."survey_members" FOR INSERT WITH CHECK (("auth"."uid"() = "user_id"));
+
+
+
+CREATE POLICY "survey_members: read if member" ON "public"."survey_members" FOR SELECT USING (("auth"."uid"() = "user_id"));
+
+
+
+ALTER TABLE "public"."survey_responses" ENABLE ROW LEVEL SECURITY;
+
+
+ALTER TABLE "public"."surveys" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "surveys: delete own" ON "public"."surveys" FOR DELETE USING (("auth"."uid"() = "created_by"));
+
+
+
+CREATE POLICY "surveys: insert own" ON "public"."surveys" FOR INSERT WITH CHECK (("auth"."uid"() = "created_by"));
+
+
+
+CREATE POLICY "surveys: read if member" ON "public"."surveys" FOR SELECT USING ((("auth"."uid"() = "created_by") OR (EXISTS ( SELECT 1
+   FROM "public"."survey_members" "sm"
+  WHERE (("sm"."survey_id" = "surveys"."id") AND ("sm"."user_id" = "auth"."uid"()))))));
+
+
+
+CREATE POLICY "surveys: update own" ON "public"."surveys" FOR UPDATE USING (("auth"."uid"() = "created_by"));
+
+
+
+CREATE POLICY "team_members: insert own" ON "public"."team_members" FOR INSERT WITH CHECK (("auth"."uid"() = "user_id"));
+
+
+
+CREATE POLICY "team_members: read if in survey" ON "public"."team_members" FOR SELECT USING ((EXISTS ( SELECT 1
+   FROM ("public"."teams" "t"
+     JOIN "public"."survey_members" "sm" ON (("sm"."survey_id" = "t"."survey_id")))
+  WHERE (("t"."id" = "team_members"."team_id") AND ("sm"."user_id" = "auth"."uid"())))));
+
+
+
+CREATE POLICY "team_members: update if team creator" ON "public"."team_members" FOR UPDATE USING ((EXISTS ( SELECT 1
+   FROM "public"."teams" "t"
+  WHERE (("t"."id" = "team_members"."team_id") AND ("t"."created_by" = "auth"."uid"())))));
+
+
+
+CREATE POLICY "teams: insert if survey member" ON "public"."teams" FOR INSERT WITH CHECK ((("auth"."uid"() = "created_by") AND (EXISTS ( SELECT 1
+   FROM "public"."survey_members" "sm"
+  WHERE (("sm"."survey_id" = "sm"."survey_id") AND ("sm"."user_id" = "auth"."uid"()))))));
+
+
+
+CREATE POLICY "teams: read if survey member" ON "public"."teams" FOR SELECT USING ((EXISTS ( SELECT 1
+   FROM "public"."survey_members" "sm"
+  WHERE (("sm"."survey_id" = "teams"."survey_id") AND ("sm"."user_id" = "auth"."uid"())))));
+
+
+
+CREATE POLICY "teams: update if creator" ON "public"."teams" FOR UPDATE USING (("auth"."uid"() = "created_by"));
+
+
+
+
+
+ALTER PUBLICATION "supabase_realtime" OWNER TO "postgres";
+
+
+GRANT USAGE ON SCHEMA "public" TO "postgres";
+GRANT USAGE ON SCHEMA "public" TO "anon";
+GRANT USAGE ON SCHEMA "public" TO "authenticated";
+GRANT USAGE ON SCHEMA "public" TO "service_role";
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+GRANT ALL ON FUNCTION "public"."handle_new_user"() TO "anon";
+GRANT ALL ON FUNCTION "public"."handle_new_user"() TO "authenticated";
+GRANT ALL ON FUNCTION "public"."handle_new_user"() TO "service_role";
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+GRANT ALL ON TABLE "public"."answer_options" TO "anon";
+GRANT ALL ON TABLE "public"."answer_options" TO "authenticated";
+GRANT ALL ON TABLE "public"."answer_options" TO "service_role";
+
+
+
+GRANT ALL ON TABLE "public"."merge_requests" TO "anon";
+GRANT ALL ON TABLE "public"."merge_requests" TO "authenticated";
+GRANT ALL ON TABLE "public"."merge_requests" TO "service_role";
+
+
+
+GRANT ALL ON TABLE "public"."profiles" TO "anon";
+GRANT ALL ON TABLE "public"."profiles" TO "authenticated";
+GRANT ALL ON TABLE "public"."profiles" TO "service_role";
+
+
+
+GRANT ALL ON TABLE "public"."questions" TO "anon";
+GRANT ALL ON TABLE "public"."questions" TO "authenticated";
+GRANT ALL ON TABLE "public"."questions" TO "service_role";
+
+
+
+GRANT ALL ON TABLE "public"."survey_members" TO "anon";
+GRANT ALL ON TABLE "public"."survey_members" TO "authenticated";
+GRANT ALL ON TABLE "public"."survey_members" TO "service_role";
+
+
+
+GRANT ALL ON TABLE "public"."survey_responses" TO "anon";
+GRANT ALL ON TABLE "public"."survey_responses" TO "authenticated";
+GRANT ALL ON TABLE "public"."survey_responses" TO "service_role";
+
+
+
+GRANT ALL ON TABLE "public"."surveys" TO "anon";
+GRANT ALL ON TABLE "public"."surveys" TO "authenticated";
+GRANT ALL ON TABLE "public"."surveys" TO "service_role";
+
+
+
+GRANT ALL ON TABLE "public"."team_members" TO "anon";
+GRANT ALL ON TABLE "public"."team_members" TO "authenticated";
+GRANT ALL ON TABLE "public"."team_members" TO "service_role";
+
+
+
+GRANT ALL ON TABLE "public"."team_sizes" TO "anon";
+GRANT ALL ON TABLE "public"."team_sizes" TO "authenticated";
+GRANT ALL ON TABLE "public"."team_sizes" TO "service_role";
+
+
+
+GRANT ALL ON TABLE "public"."teams" TO "anon";
+GRANT ALL ON TABLE "public"."teams" TO "authenticated";
+GRANT ALL ON TABLE "public"."teams" TO "service_role";
+
+
+
+GRANT ALL ON TABLE "public"."user_active_teams" TO "anon";
+GRANT ALL ON TABLE "public"."user_active_teams" TO "authenticated";
+GRANT ALL ON TABLE "public"."user_active_teams" TO "service_role";
+
+
+
+
+
+
+
+
+
+ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT ALL ON SEQUENCES TO "postgres";
+ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT ALL ON SEQUENCES TO "anon";
+ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT ALL ON SEQUENCES TO "authenticated";
+ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT ALL ON SEQUENCES TO "service_role";
+
+
+
+
+
+
+ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT ALL ON FUNCTIONS TO "postgres";
+ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT ALL ON FUNCTIONS TO "anon";
+ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT ALL ON FUNCTIONS TO "authenticated";
+ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT ALL ON FUNCTIONS TO "service_role";
+
+
+
+
+
+
+ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT ALL ON TABLES TO "postgres";
+ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT ALL ON TABLES TO "anon";
+ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT ALL ON TABLES TO "authenticated";
+ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT ALL ON TABLES TO "service_role";
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+drop extension if exists "pg_net";
+
+CREATE TRIGGER on_auth_user_created AFTER INSERT ON auth.users FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
+
+

--- a/supabase/migrations/20260506030000_add_role_to_profiles.sql
+++ b/supabase/migrations/20260506030000_add_role_to_profiles.sql
@@ -1,0 +1,3 @@
+ALTER TABLE public.profiles
+ADD COLUMN IF NOT EXISTS role text NOT NULL DEFAULT 'member'
+CHECK (role IN ('member', 'survey_creator'));

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,66 @@
+-- Playwright E2E seed — run once after `npx supabase start`
+-- Creates 3 stable test users that all E2E tests rely on.
+--
+-- Credentials:
+--   e2e_creator@commonground.dev  / E2ePass1!  (survey_creator)
+--   e2e_member_a@commonground.dev / E2ePass1!  (member)
+--   e2e_member_b@commonground.dev / E2ePass1!  (member)
+--
+-- To apply:
+--   psql postgresql://postgres:postgres@127.0.0.1:54322/postgres -f frontend/e2e/playwright_seed.sql
+
+SET session_replication_role = replica;
+
+DO $$
+DECLARE
+  pw          TEXT        := extensions.crypt('E2ePass1!', extensions.gen_salt('bf', 10));
+  ts          TIMESTAMPTZ := now();
+
+  creator_id  UUID := 'e2e00000-0000-0000-0000-000000000001';
+  member_a_id UUID := 'e2e00000-0000-0000-0000-000000000002';
+  member_b_id UUID := 'e2e00000-0000-0000-0000-000000000003';
+
+BEGIN
+
+-- ── Auth users ─────────────────────────────────────────────────────────────────
+
+INSERT INTO auth.users (
+  instance_id, id, aud, role, email, encrypted_password,
+  email_confirmed_at, invited_at,
+  confirmation_token, confirmation_sent_at,
+  recovery_token, recovery_sent_at,
+  email_change_token_new, email_change, email_change_sent_at,
+  last_sign_in_at, raw_app_meta_data, raw_user_meta_data,
+  is_super_admin, created_at, updated_at,
+  phone, phone_confirmed_at,
+  phone_change, phone_change_token, phone_change_sent_at,
+  email_change_token_current, email_change_confirm_status,
+  banned_until, reauthentication_token, reauthentication_sent_at,
+  is_sso_user, deleted_at, is_anonymous
+) VALUES
+  ('00000000-0000-0000-0000-000000000000', creator_id,  'authenticated','authenticated','e2e_creator@commonground.dev',  pw, ts,NULL,'',NULL,'',NULL,'','',NULL,NULL,'{"provider":"email","providers":["email"]}','{"email_verified":true}',NULL,ts,ts,NULL,NULL,'','',NULL,'',0,NULL,'',NULL,false,NULL,false),
+  ('00000000-0000-0000-0000-000000000000', member_a_id, 'authenticated','authenticated','e2e_member_a@commonground.dev', pw, ts,NULL,'',NULL,'',NULL,'','',NULL,NULL,'{"provider":"email","providers":["email"]}','{"email_verified":true}',NULL,ts,ts,NULL,NULL,'','',NULL,'',0,NULL,'',NULL,false,NULL,false),
+  ('00000000-0000-0000-0000-000000000000', member_b_id, 'authenticated','authenticated','e2e_member_b@commonground.dev', pw, ts,NULL,'',NULL,'',NULL,'','',NULL,NULL,'{"provider":"email","providers":["email"]}','{"email_verified":true}',NULL,ts,ts,NULL,NULL,'','',NULL,'',0,NULL,'',NULL,false,NULL,false)
+ON CONFLICT (id) DO NOTHING;
+
+-- ── Auth identities ────────────────────────────────────────────────────────────
+
+INSERT INTO auth.identities (provider_id, user_id, identity_data, provider, last_sign_in_at, created_at, updated_at, id) VALUES
+  (creator_id::text,  creator_id,  jsonb_build_object('sub',creator_id::text,  'email','e2e_creator@commonground.dev',  'email_verified',false,'phone_verified',false),'email',ts,ts,ts,gen_random_uuid()),
+  (member_a_id::text, member_a_id, jsonb_build_object('sub',member_a_id::text, 'email','e2e_member_a@commonground.dev', 'email_verified',false,'phone_verified',false),'email',ts,ts,ts,gen_random_uuid()),
+  (member_b_id::text, member_b_id, jsonb_build_object('sub',member_b_id::text, 'email','e2e_member_b@commonground.dev', 'email_verified',false,'phone_verified',false),'email',ts,ts,ts,gen_random_uuid())
+ON CONFLICT (provider_id, provider) DO NOTHING;
+
+-- ── Profiles ───────────────────────────────────────────────────────────────────
+-- Use UPSERT so re-running the seed is safe even if the trigger already fired.
+
+INSERT INTO public.profiles (id, email, full_name, school, major, grad_year, role, created_at, updated_at) VALUES
+  (creator_id,  'e2e_creator@commonground.dev',  'E2E Creator',  'UMass Amherst', 'Computer Science', 2026, 'survey_creator', ts, ts),
+  (member_a_id, 'e2e_member_a@commonground.dev', 'E2E Member A', 'UMass Amherst', 'Computer Science', 2026, 'member',          ts, ts),
+  (member_b_id, 'e2e_member_b@commonground.dev', 'E2E Member B', 'UMass Amherst', 'Computer Science', 2026, 'member',          ts, ts)
+ON CONFLICT (id) DO UPDATE
+  SET role = EXCLUDED.role, full_name = EXCLUDED.full_name, updated_at = now();
+
+END $$;
+
+SET session_replication_role = DEFAULT;


### PR DESCRIPTION
Adds a Playwright E2E test suite covering three flows: auth (login, logout, wrong password, registration), survey creation and join-by-code, and answer submission with pre-population on reload.

Also fixes a bug in the survey response upsert where the wrong conflict columns were specified, causing saved answers to be silently discarded.

Note: Tests only run against a local Supabase instance with the seed file applied. See the README for full setup instructions (npx supabase start → npx supabase db reset → run backend → npm run test:e2e).